### PR TITLE
feat: 목소리 설정 화면 UI 및 저장 플로우 구현

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,18 +4,6 @@
     <selectionStates>
       <SelectionState runConfigName="aac">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-01-20T14:35:41.663072Z">
-          <Target type="DEFAULT_BOOT">
-            <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/coffeepeanut/.android/avd/Pixel_Tablet.avd" />
-        <DropdownSelection timestamp="2026-01-27T07:40:14.382488Z">
-          <Target type="DEFAULT_BOOT">
-            <handle>
-              <DeviceId pluginId="PhysicalDevice" identifier="serial=R54Y30168HJ" />
-            </handle>
-          </Target>
-        </DropdownSelection>
-        <DialogSelection />
       </SelectionState>
     </selectionStates>
   </component>

--- a/app/src/main/java/com/example/aac/core/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/example/aac/core/navigation/AppNavGraph.kt
@@ -13,7 +13,7 @@ import com.example.aac.ui.features.login.LoginScreen
 import com.example.aac.ui.features.settings.SettingsScreen
 import com.example.aac.ui.features.auto_sentence.*
 import com.example.aac.ui.features.auto_sentence.AutoSentenceSelectDeleteScreen
-
+import com.example.aac.ui.features.voice_setting.VoiceSettingScreen
 
 @Composable
 fun AppNavGraph() {
@@ -23,6 +23,9 @@ fun AppNavGraph() {
     var autoSentenceList by remember {
         mutableStateOf(listOf<AutoSentenceItem>())
     }
+
+    // 목소리 설정 정보 반영 데이터
+    var voiceSettingId by remember { mutableStateOf("default_male") }
 
     NavHost(
         navController = navController,
@@ -67,6 +70,22 @@ fun AppNavGraph() {
                 onBackClick = { navController.popBackStack() },
                 onAutoSentenceSettingClick = {
                     navController.navigate(Routes.AUTO_SENTENCE_SETTING)
+                },
+                onVoiceSettingClick = {
+                    navController.navigate(Routes.VOICE_SETTING)
+                }
+            )
+        }
+
+        /* ---------- VOICE SETTING ---------- */
+        composable(Routes.VOICE_SETTING) {
+            VoiceSettingScreen(
+                initialSelectedId = voiceSettingId,
+                onBackClick = { navController.popBackStack() },
+                onSave = { selectedId ->
+                    voiceSettingId = selectedId
+                    // TODO: 나중에 API 저장 연결
+                    // 지금은 아무것도 안 해도 됨
                 }
             )
         }
@@ -107,9 +126,7 @@ fun AppNavGraph() {
                 },
                 autoSentenceList = autoSentenceList
             )
-
         }
-
 
         /* ---------- AUTO SENTENCE ADD ---------- */
         composable(Routes.AUTO_SENTENCE_ADD) {
@@ -159,10 +176,10 @@ fun AppNavGraph() {
                         navController.popBackStack()
                     }
                 )
-
             }
         }
 
+        /* ---------- AUTO SENTENCE SELECT DELETE ---------- */
         composable(Routes.AUTO_SENTENCE_SELECT_DELETE) {
             AutoSentenceSelectDeleteScreen(
                 autoSentenceList = autoSentenceList,
@@ -174,6 +191,5 @@ fun AppNavGraph() {
                 }
             )
         }
-
     }
 }

--- a/app/src/main/java/com/example/aac/core/navigation/Routes.kt
+++ b/app/src/main/java/com/example/aac/core/navigation/Routes.kt
@@ -40,4 +40,7 @@ object Routes {
     // 자동 출력 문장 선택 삭제 화면
     const val AUTO_SENTENCE_SELECT_DELETE = "auto_sentence_select_delete"
 
+    // 목소리 설정 화면
+    const val VOICE_SETTING = "voice_setting"
+
 }

--- a/app/src/main/java/com/example/aac/ui/features/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/example/aac/ui/features/settings/SettingsActivity.kt
@@ -14,6 +14,9 @@ class SettingsActivity : ComponentActivity() {
                     onBackClick = { finish() },
                     onAutoSentenceSettingClick = {
                         // Activity에서는 아직 안 씀
+                    },
+                    onVoiceSettingClick = {
+                        // Activity에서는 아직 안 씀
                     }
                 )
             }

--- a/app/src/main/java/com/example/aac/ui/features/settings/SettingsScreent.kt
+++ b/app/src/main/java/com/example/aac/ui/features/settings/SettingsScreent.kt
@@ -25,6 +25,7 @@ import com.example.aac.ui.features.settings.components.*
 @Composable
 fun SettingsScreen(
     onBackClick: () -> Unit,
+    onVoiceSettingClick: () -> Unit,
     onAutoSentenceSettingClick: () -> Unit
 ) {
     Scaffold(
@@ -52,7 +53,7 @@ fun SettingsScreen(
             // 3개 퀵액션 카드
             SettingsQuickActionRow(
                 onCategoryClick = { /* TODO */ },
-                onVoiceClick = { /* TODO */ },
+                onVoiceClick = onVoiceSettingClick,
                 onAutoSentenceClick = onAutoSentenceSettingClick
             )
 
@@ -177,6 +178,7 @@ fun SettingsTopBar(
 fun SettingsScreenPreview() {
     SettingsScreen(
         onBackClick = {},
+        onVoiceSettingClick = {},
         onAutoSentenceSettingClick = {}
     )
 }

--- a/app/src/main/java/com/example/aac/ui/features/voice_setting/Circle.kt
+++ b/app/src/main/java/com/example/aac/ui/features/voice_setting/Circle.kt
@@ -1,0 +1,42 @@
+package com.example.aac.ui.features.voice_setting
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.example.aac.R
+
+@Composable
+fun Circle(
+    selected: Boolean,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .size(30.dp)
+            .then(
+                if (selected) {
+                    Modifier.background(Color(0xFF0088FF), CircleShape)
+                } else {
+                    Modifier.border(1.dp, Color(0xFFD9D9D9), CircleShape)
+                }
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        if (selected) {
+            Image(
+                painter = painterResource(id = R.drawable.ic_check),
+                contentDescription = "checked",
+                modifier = Modifier.size(30.dp)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/aac/ui/features/voice_setting/CommonTopBar.kt
+++ b/app/src/main/java/com/example/aac/ui/features/voice_setting/CommonTopBar.kt
@@ -1,0 +1,77 @@
+package com.example.aac.ui.features.voice_setting
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.aac.R
+
+@Composable
+fun CommonTopBar(
+    title: String,
+    rightText: String,
+    onBackClick: () -> Unit,
+    onRightClick: () -> Unit,
+    rightTextColor: Color = Color.Black
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .statusBarsPadding()
+            .padding(horizontal = 24.dp, vertical = 12.dp)
+    ) {
+
+        // 가운데 타이틀
+        Text(
+            text = title,
+            fontSize = 28.sp,
+            fontWeight = FontWeight.SemiBold,
+            color = Color(0xFF2C2C2C),
+            textAlign = TextAlign.Center,
+            modifier = Modifier.align(Alignment.Center)
+        )
+
+        // 뒤로가기
+        Row(
+            modifier = Modifier
+                .align(Alignment.CenterStart)
+                .clickable(onClick = onBackClick),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.ic_back_circle),
+                contentDescription = "Back",
+                modifier = Modifier.size(45.dp)
+            )
+
+            Spacer(modifier = Modifier.width(8.dp))
+
+            Text(
+                text = "뒤로가기",
+                fontSize = 18.sp,
+                fontWeight = FontWeight.Normal,
+                color = Color(0xFF373737)
+            )
+        }
+
+        // 우측 액션
+        Text(
+            text = rightText,
+            fontSize = 20.sp,
+            fontWeight = FontWeight.Medium,
+            color = rightTextColor,
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .clickable(onClick = onRightClick)
+        )
+    }
+}

--- a/app/src/main/java/com/example/aac/ui/features/voice_setting/SoundButton.kt
+++ b/app/src/main/java/com/example/aac/ui/features/voice_setting/SoundButton.kt
@@ -1,0 +1,53 @@
+package com.example.aac.ui.features.voice_setting
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.aac.R
+
+@Composable
+fun SoundButton(
+    onClick: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .size(58.dp)
+            .background(
+                color = Color(0xFF3199FF),
+                shape = RoundedCornerShape(12.dp)
+            )
+            .clickable(onClick = onClick),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+
+        Icon(
+            painter = painterResource(id = R.drawable.ic_sound),
+            contentDescription = "재생",
+            tint = Color.White,
+            modifier = Modifier.size(22.dp)
+        )
+
+        Text(
+            text = "재생",
+            fontSize = 12.sp,
+            color = Color.White,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}

--- a/app/src/main/java/com/example/aac/ui/features/voice_setting/VoiceOption.kt
+++ b/app/src/main/java/com/example/aac/ui/features/voice_setting/VoiceOption.kt
@@ -1,0 +1,6 @@
+package com.example.aac.ui.features.voice_setting
+
+data class VoiceOption(
+    val id: String,
+    val title: String
+)

--- a/app/src/main/java/com/example/aac/ui/features/voice_setting/VoiceOptionCard.kt
+++ b/app/src/main/java/com/example/aac/ui/features/voice_setting/VoiceOptionCard.kt
@@ -1,0 +1,48 @@
+package com.example.aac.ui.features.voice_setting
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun VoiceOptionCard(
+    title: String,
+    selected: Boolean,
+    onCardClick: () -> Unit,
+    onPreviewClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    VoiceOptionCardFrame(
+        modifier = modifier.clickable(onClick = onCardClick)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxSize(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Circle(selected = selected)
+
+                Spacer(modifier = Modifier.width(12.dp)) // 원-텍스트 간격(나중에 피그마값으로 조정)
+
+                Text(
+                    text = title,
+                    fontSize = 24.sp,
+                    fontWeight = FontWeight.Medium,
+                    color = Color(0xFF2C2C2C)
+                )
+            }
+
+            SoundButton(onClick = onPreviewClick)
+        }
+    }
+}

--- a/app/src/main/java/com/example/aac/ui/features/voice_setting/VoiceOptionCardFrame.kt
+++ b/app/src/main/java/com/example/aac/ui/features/voice_setting/VoiceOptionCardFrame.kt
@@ -1,0 +1,37 @@
+package com.example.aac.ui.features.voice_setting
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun VoiceOptionCardFrame(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit = {}
+) {
+    val shape = RoundedCornerShape(12.dp)
+
+    Box(
+        modifier = modifier
+            .width(1118.dp)
+            .height(78.dp)
+            .background(Color(0xFFFFFFFF), shape)
+            .border(1.dp, Color(0xFFD9D9D9), shape)
+            .padding(
+                start = 19.dp,
+                end = 19.dp,
+                top = 10.dp,
+                bottom = 10.dp
+            )
+    ) {
+        content()
+    }
+}

--- a/app/src/main/java/com/example/aac/ui/features/voice_setting/VoiceSaveDialog.kt
+++ b/app/src/main/java/com/example/aac/ui/features/voice_setting/VoiceSaveDialog.kt
@@ -1,0 +1,115 @@
+package com.example.aac.ui.features.voice_setting
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+
+@Composable
+fun VoiceSaveDialog(
+    onCancel: () -> Unit,
+    onSave: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Dialog(
+        onDismissRequest = onCancel,
+        properties = DialogProperties(
+            dismissOnBackPress = true,
+            dismissOnClickOutside = true
+        )
+    ) {
+        Box(
+            modifier = modifier
+                .width(451.dp)
+                .height(317.dp)
+                .background(Color.White, RoundedCornerShape(32.dp))
+                .padding(
+                    start = 51.dp,
+                    end = 51.dp,
+                    top = 64.dp,
+                    bottom = 48.dp
+                )
+        ) {
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = "변경 사항을\n저장 하시겠어요?",
+                    fontSize = 32.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = Color(0xFF2C2C2C),
+                    textAlign = TextAlign.Center,
+                    lineHeight = 40.sp // 줄간격은 피그마 값 없어서 보기 좋은 값으로(필요하면 조정)
+                )
+
+                Spacer(modifier = Modifier.height(61.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(15.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    DialogButton(
+                        text = "취소",
+                        background = Color(0xFFE2E5EA),
+                        borderColor = Color(0xFFD9D9D9),
+                        textColor = Color.Black,
+                        onClick = onCancel,
+                        modifier = Modifier.weight(1f)
+                    )
+
+                    DialogButton(
+                        text = "저장",
+                        background = Color(0xFF0088FF),
+                        borderColor = Color(0xFFD9D9D9),
+                        textColor = Color.White,
+                        onClick = onSave,
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DialogButton(
+    text: String,
+    background: Color,
+    borderColor: Color,
+    textColor: Color,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .height(60.dp)
+            .fillMaxWidth()
+            .background(background, RoundedCornerShape(8.dp))
+            .border(1.dp, borderColor, RoundedCornerShape(8.dp))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 21.dp, vertical = 9.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = text,
+            fontSize = 20.sp,
+            fontWeight = FontWeight.Medium,
+            color = textColor
+        )
+    }
+}
+

--- a/app/src/main/java/com/example/aac/ui/features/voice_setting/VoiceSettingScreen.kt
+++ b/app/src/main/java/com/example/aac/ui/features/voice_setting/VoiceSettingScreen.kt
@@ -1,0 +1,93 @@
+package com.example.aac.ui.features.voice_setting
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun VoiceSettingScreen(
+    initialSelectedId: String,
+    onBackClick: () -> Unit = {},
+    onSave: (String) -> Unit = {} // 나중에 API 연결 포인트
+) {
+    val options = remember {
+        listOf(
+            VoiceOption("boy", "남자 아이 목소리"),
+            VoiceOption("girl", "여자 아이 목소리"),
+            VoiceOption("default_male", "기본 남성 목소리"),
+            VoiceOption("default_female", "기본 여성 목소리"),
+            VoiceOption("grandpa", "할아버지 목소리"),
+            VoiceOption("grandma", "할머니 목소리"),
+        )
+    }
+
+    // initialSelectedId가 바뀌면 selectedId도 그 값으로 다시 시작
+    var selectedId by remember(initialSelectedId) { mutableStateOf(initialSelectedId) }
+    val hasChanges = selectedId != initialSelectedId
+
+    var showSaveDialog by remember { mutableStateOf(false) }
+
+    BackHandler {
+        if (hasChanges) showSaveDialog = true
+        else onBackClick()
+    }
+
+    if (showSaveDialog) {
+        VoiceSaveDialog(
+            onCancel = { showSaveDialog = false },
+            onSave = {
+                showSaveDialog = false
+                onSave(selectedId)
+                onBackClick()
+            }
+        )
+    }
+
+    Scaffold(
+        containerColor = Color(0xFFF4F4F4),
+        topBar = {
+            CommonTopBar(
+                title = "목소리 설정",
+                rightText = "저장하기",
+                onBackClick = {
+                    if (hasChanges) showSaveDialog = true
+                    else onBackClick()
+                },
+                onRightClick = {
+                    // 저장하기는 모달 없이 저장 반영 + 이동
+                    onSave(selectedId)
+                    onBackClick()
+                },
+                rightTextColor = Color(0xFF2D7DFF)
+            )
+        }
+    ) { innerPadding ->
+
+        LazyColumn(
+            modifier = Modifier
+                .padding(innerPadding)
+                .padding(top = 25.dp)
+                .fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            items(options, key = { it.id }) { option ->
+                VoiceOptionCard(
+                    title = option.title,
+                    selected = option.id == selectedId,
+                    onCardClick = { selectedId = option.id },
+                    onPreviewClick = { /* TODO */ }
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
- 목소리 설정 화면 UI 구현 (6개의 카드리스트로 구현)
- 카드 선택(체크 표시) 및 미리 듣기 버튼 UI 적용
- 변경사항 존재 시 뒤로가기 모달 노출, 저장하기 클릭 시 저장 반영 후 설정 화면으로 이동
- API 연동 전 임시로 AppNavGraph 상태로 선택값 유지 처리 (API 연동 전 기능)