### PR TITLE
[Auth] 로그인 이후 인증 흐름 정리 및 로그아웃/회원탈퇴 기능 구현

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetSelector">
+    <selectionStates>
+      <SelectionState runConfigName="aac">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+    </selectionStates>
+  </component>
+</project>

--- a/app/src/main/java/com/example/aac/core/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/example/aac/core/navigation/AppNavGraph.kt
@@ -142,6 +142,20 @@ fun AppNavGraph() {
 
                 onSpeakSettingClick = {
                     navController.navigate(Routes.SPEAK_SETTING)
+                },
+
+                // 로그아웃 성공 → 초기 화면
+                onLogoutSuccess = {
+                    navController.navigate(Routes.LOGIN) {
+                        popUpTo(0) { inclusive = true }
+                    }
+                },
+
+                // 회원탈퇴 성공 → 초기 화면
+                onWithdrawSuccess = {
+                    navController.navigate(Routes.LOGIN) {
+                        popUpTo(0) { inclusive = true }
+                    }
                 }
             )
         }

--- a/app/src/main/java/com/example/aac/data/local/TokenDataStore.kt
+++ b/app/src/main/java/com/example/aac/data/local/TokenDataStore.kt
@@ -1,6 +1,7 @@
 package com.example.aac.data.local
 
 import android.content.Context
+import androidx.datastore.dataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
@@ -23,5 +24,11 @@ class TokenDataStore(private val context: Context) {
 
     suspend fun getAccessToken(): String? {
         return context.dataStore.data.first()[ACCESS_TOKEN]
+    }
+
+    suspend fun clearAccessToken() {
+        context.dataStore.edit { prefs ->
+            prefs.remove(ACCESS_TOKEN)
+        }
     }
 }

--- a/app/src/main/java/com/example/aac/data/mapper/MyInfoMapper.kt
+++ b/app/src/main/java/com/example/aac/data/mapper/MyInfoMapper.kt
@@ -1,0 +1,15 @@
+package com.example.aac.data.mapper
+
+import com.example.aac.data.remote.dto.MyInfoResponse
+import com.example.aac.domain.model.MyInfo
+
+fun MyInfoResponse.toMyInfo(): MyInfo? {
+    if (!success || data == null) return null
+
+    return MyInfo(
+        id = data.id,
+        nickname = data.nickname,
+        email = data.email,
+        accountType = data.accountType
+    )
+}

--- a/app/src/main/java/com/example/aac/data/remote/api/AacApiService.kt
+++ b/app/src/main/java/com/example/aac/data/remote/api/AacApiService.kt
@@ -1,5 +1,6 @@
 package com.example.aac.data.remote.api
 
+import com.example.aac.data.remote.dto.BaseResponse
 import com.example.aac.data.remote.dto.GridSettingRequest
 import com.example.aac.data.remote.dto.GridSettingResponse
 import com.example.aac.data.remote.dto.GuestLoginRequest
@@ -8,6 +9,7 @@ import com.example.aac.data.remote.dto.MyInfoResponse
 import com.example.aac.data.remote.dto.WordResponse
 import com.example.aac.data.remote.dto.LogoutResponse
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.POST
@@ -42,4 +44,8 @@ interface AacApiService {
     // [Auth] 로그아웃
     @POST("api/auth/logout")
     suspend fun logout(): LogoutResponse
+
+    // [Auth] 회원탈퇴
+    @DELETE("api/auth/account")
+    suspend fun withdraw(): BaseResponse<Unit>
 }

--- a/app/src/main/java/com/example/aac/data/remote/api/AacApiService.kt
+++ b/app/src/main/java/com/example/aac/data/remote/api/AacApiService.kt
@@ -4,6 +4,7 @@ import com.example.aac.data.remote.dto.GridSettingRequest
 import com.example.aac.data.remote.dto.GridSettingResponse
 import com.example.aac.data.remote.dto.GuestLoginRequest
 import com.example.aac.data.remote.dto.GuestLoginResponse
+import com.example.aac.data.remote.dto.MyInfoResponse
 import com.example.aac.data.remote.dto.WordResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -32,4 +33,8 @@ interface AacApiService {
     suspend fun updateGridSetting(
         @Body request: GridSettingRequest
     ): GridSettingResponse
+
+    // [Auth] 내 정보 조회 (로그인 상태 확인용)
+    @GET("api/auth/me")
+    suspend fun getMyInfo(): MyInfoResponse
 }

--- a/app/src/main/java/com/example/aac/data/remote/api/AacApiService.kt
+++ b/app/src/main/java/com/example/aac/data/remote/api/AacApiService.kt
@@ -6,6 +6,7 @@ import com.example.aac.data.remote.dto.GuestLoginRequest
 import com.example.aac.data.remote.dto.GuestLoginResponse
 import com.example.aac.data.remote.dto.MyInfoResponse
 import com.example.aac.data.remote.dto.WordResponse
+import com.example.aac.data.remote.dto.LogoutResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.PATCH
@@ -37,4 +38,8 @@ interface AacApiService {
     // [Auth] 내 정보 조회 (로그인 상태 확인용)
     @GET("api/auth/me")
     suspend fun getMyInfo(): MyInfoResponse
+
+    // [Auth] 로그아웃
+    @POST("api/auth/logout")
+    suspend fun logout(): LogoutResponse
 }

--- a/app/src/main/java/com/example/aac/data/remote/dto/BaseResponse.kt
+++ b/app/src/main/java/com/example/aac/data/remote/dto/BaseResponse.kt
@@ -1,0 +1,14 @@
+package com.example.aac.data.remote.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class BaseResponse<T>(
+    @SerializedName("success")
+    val success: Boolean,
+
+    @SerializedName("data")
+    val data: T?,
+
+    @SerializedName("message")
+    val message: String?
+)

--- a/app/src/main/java/com/example/aac/data/remote/dto/LogoutResponse.kt
+++ b/app/src/main/java/com/example/aac/data/remote/dto/LogoutResponse.kt
@@ -1,0 +1,7 @@
+package com.example.aac.data.remote.dto
+
+data class LogoutResponse (
+    val success: Boolean,
+    val data: Any?,
+    val message: String?
+)

--- a/app/src/main/java/com/example/aac/data/remote/dto/MyInfoResponse.kt
+++ b/app/src/main/java/com/example/aac/data/remote/dto/MyInfoResponse.kt
@@ -1,0 +1,32 @@
+package com.example.aac.data.remote.dto
+
+data class MyInfoResponse(
+    val success: Boolean,
+    val data: MyInfoData?,
+    val message: String?
+)
+
+data class MyInfoData(
+    val id: String,
+    val nickname: String,
+    val email: String?,
+    val accountType: String,
+    val createdAt: String,
+    val lastLoginAt: String,
+    val settings: UserSettings,
+    val subscription: UserSubscription
+)
+
+data class UserSettings(
+    val ttsVoiceType: String,
+    val ttsAgeType: String,
+    val ttsTone: String,
+    val gridColumns: Int
+)
+
+data class UserSubscription(
+    val planType: String,
+    val status: String,
+    val startDate: String,
+    val endDate: String
+)

--- a/app/src/main/java/com/example/aac/domain/model/MyInfo.kt
+++ b/app/src/main/java/com/example/aac/domain/model/MyInfo.kt
@@ -1,0 +1,8 @@
+package com.example.aac.domain.model
+
+data class MyInfo(
+    val id: String,
+    val nickname: String,
+    val email: String?,
+    val accountType: String
+)

--- a/app/src/main/java/com/example/aac/ui/features/auth/AuthViewModel.kt
+++ b/app/src/main/java/com/example/aac/ui/features/auth/AuthViewModel.kt
@@ -6,20 +6,32 @@ import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.aac.data.mapper.toLoginState
+import com.example.aac.data.mapper.toMyInfo
 import com.example.aac.data.remote.api.RetrofitInstance
 import com.example.aac.data.remote.dto.GuestLoginRequest
 import com.example.aac.domain.model.LoginState
+import com.example.aac.domain.model.MyInfo
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import retrofit2.HttpException
 import java.util.UUID
 
 class AuthViewModel(
     application: Application
 ) : AndroidViewModel(application) {
 
+    /* ------------------ 로그인 상태 ------------------ */
+
     private val _loginState = MutableStateFlow<LoginState?>(null)
     val loginState: StateFlow<LoginState?> = _loginState
+
+    /* ------------------ 내 정보 (auth/me) ------------------ */
+
+    private val _myInfo = MutableStateFlow<MyInfo?>(null)
+    val myInfo: StateFlow<MyInfo?> = _myInfo
+
+    /* ------------------ 게스트 로그인 ------------------ */
 
     fun startAsGuest() {
         viewModelScope.launch {
@@ -29,7 +41,7 @@ class AuthViewModel(
                 val deviceId = getDeviceId()
                 Log.d("AuthTest", "deviceId = $deviceId")
 
-                // 로그인 API 호출
+                // 1. 게스트 로그인 API 호출
                 val response = RetrofitInstance.api.createGuestAccount(
                     GuestLoginRequest(deviceId = deviceId)
                 )
@@ -39,13 +51,25 @@ class AuthViewModel(
                 if (response.success) {
                     val loginState = response.toLoginState()
 
-                    RetrofitInstance.tokenDataStore.saveAccessToken(loginState.accessToken)
+                    // 2. 토큰 저장 (핵심 규칙)
+                    RetrofitInstance.tokenDataStore
+                        .saveAccessToken(loginState.accessToken)
 
-                    Log.d("AuthTest", "토큰 저장 완료! (이제 401 안 뜸): ${loginState.accessToken}")
+                    Log.d(
+                        "AuthTest",
+                        "토큰 저장 완료! (이제 401 안 뜸): ${loginState.accessToken}"
+                    )
 
                     _loginState.value = loginState
+
+                    // 3. 로그인 직후 내 정보 조회 → 토큰 검증
+                    fetchMyInfo()
+
                 } else {
-                    Log.e("AuthTest", "Guest login response failed: ${response.message}")
+                    Log.e(
+                        "AuthTest",
+                        "Guest login response failed: ${response.message}"
+                    )
                 }
 
             } catch (e: Exception) {
@@ -53,6 +77,43 @@ class AuthViewModel(
             }
         }
     }
+
+    /* ------------------ 내 정보 조회 (auth/me) ------------------ */
+
+    fun fetchMyInfo() {
+        viewModelScope.launch {
+            try {
+                val response = RetrofitInstance.api.getMyInfo()
+
+                if (response.success) {
+                    _myInfo.value = response.toMyInfo()
+                    Log.d(
+                        "AuthTest",
+                        "내 정보 조회 성공: ${_myInfo.value}"
+                    )
+                } else {
+                    Log.e(
+                        "AuthTest",
+                        "내 정보 조회 실패: ${response.message}"
+                    )
+                }
+
+            } catch (e: HttpException) {
+                if (e.code() == 401) {
+                    Log.e(
+                        "AuthTest",
+                        "토큰 만료 또는 미로그인 상태 (401)"
+                    )
+                    _myInfo.value = null
+                    // TODO: 로그아웃 처리 연결
+                }
+            } catch (e: Exception) {
+                Log.e("AuthTest", "내 정보 조회 예외", e)
+            }
+        }
+    }
+
+    /* ------------------ Device ID ------------------ */
 
     private fun getDeviceId(): String {
         val androidId = Settings.Secure.getString(

--- a/app/src/main/java/com/example/aac/ui/features/auth/AuthViewModel.kt
+++ b/app/src/main/java/com/example/aac/ui/features/auth/AuthViewModel.kt
@@ -113,6 +113,28 @@ class AuthViewModel(
         }
     }
 
+    /* ------------------ 회원탈퇴 (auth/withdraw) ------------------ */
+
+    fun withdraw() {
+        viewModelScope.launch {
+            try {
+                RetrofitInstance.api.withdraw()
+
+                Log.d("AuthTest", "서버 회원탈퇴 완료")
+
+                RetrofitInstance.tokenDataStore.clearAccessToken()
+                _loginState.value = null
+                _myInfo.value = null
+
+                Log.d("AuthTest", "로컬 탈퇴 처리 완료")
+
+            } catch (e: Exception) {
+                Log.e("AuthTest", "회원탈퇴 실패", e)
+            }
+        }
+    }
+
+
 
     /* ------------------ 내 정보 조회 (auth/me) ------------------ */
 

--- a/app/src/main/java/com/example/aac/ui/features/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/example/aac/ui/features/settings/SettingsActivity.kt
@@ -20,7 +20,7 @@ class SettingsActivity : ComponentActivity() {
                     onVoiceSettingClick = {
                         // Activity에서는 아직 안 씀
                     },
-                    // 👇 여기를 추가해주세요!
+
                     onUsageHistoryClick = {
                         val intent = Intent(this, UsageHistoryActivity::class.java)
                         startActivity(intent)

--- a/app/src/main/java/com/example/aac/ui/features/settings/SettingsScreent.kt
+++ b/app/src/main/java/com/example/aac/ui/features/settings/SettingsScreent.kt
@@ -31,7 +31,6 @@ fun SettingsScreen(
 
     val authViewModel: AuthViewModel = viewModel()
 
-
     var showLogoutModal by remember { mutableStateOf(false) }
     var showWithdrawModal by remember { mutableStateOf(false) }
 
@@ -119,7 +118,7 @@ fun SettingsScreen(
             onCancel = { showLogoutModal = false },
             onLogout = {
                 showLogoutModal = false
-                // 🔥 로그아웃 실행
+                // 로그아웃 실행
                 authViewModel.logout()
                 // (지금은 그냥 콜백만 호출)
                 onLogoutSuccess()
@@ -132,9 +131,12 @@ fun SettingsScreen(
             onCancel = { showWithdrawModal = false },
             onWithdraw = {
                 showWithdrawModal = false
-                // TODO: 회원탈퇴 API 연결
+                // 회원탈퇴 실행
+                authViewModel.withdraw()
+                // 탈퇴 후 화면 이동
                 onWithdrawSuccess()
             }
+
         )
     }
 }

--- a/app/src/main/java/com/example/aac/ui/features/settings/SettingsScreent.kt
+++ b/app/src/main/java/com/example/aac/ui/features/settings/SettingsScreent.kt
@@ -13,6 +13,8 @@ import androidx.compose.ui.unit.dp
 import com.example.aac.R
 import com.example.aac.ui.components.CustomTopBar
 import com.example.aac.ui.features.settings.components.*
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.aac.ui.features.auth.AuthViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -26,6 +28,9 @@ fun SettingsScreen(
     onCategoryManagementClick: () -> Unit,
     onSpeakSettingClick: () -> Unit
 ) {
+
+    val authViewModel: AuthViewModel = viewModel()
+
 
     var showLogoutModal by remember { mutableStateOf(false) }
     var showWithdrawModal by remember { mutableStateOf(false) }
@@ -114,7 +119,9 @@ fun SettingsScreen(
             onCancel = { showLogoutModal = false },
             onLogout = {
                 showLogoutModal = false
-                // TODO: 로그아웃 API 연결
+                // 🔥 로그아웃 실행
+                authViewModel.logout()
+                // (지금은 그냥 콜백만 호출)
                 onLogoutSuccess()
             }
         )


### PR DESCRIPTION
## 작업 내용 요약

인증(Auth) 관련 기본 흐름을 정리하고,  
로그아웃 및 회원탈퇴 기능까지 한 사이클로 구현했습니다.

### 구현 사항
- 게스트 로그인 이후 accessToken 저장
- 로그인 직후 `auth/me` 호출로 내 정보 자동 조회
- AuthInterceptor를 통한 인증 헤더 자동 처리
- 로그아웃 API 연동 및 로컬 토큰 삭제
- 회원탈퇴 API 연동 및 로컬 인증 상태 초기화
- 로그아웃 / 회원탈퇴 시 로그인 화면으로 이동 (백스택 초기화)

---

## 테스트 방법
1. 앱 실행 후 게스트 로그인
2. 설정 화면 진입
3. **로그아웃**
   - 로그인 화면으로 이동
   - 뒤로 가기 시 이전 화면으로 돌아가지 않음
4. 다시 로그인 후 **회원탈퇴**
   - 로그인 화면으로 이동
   - 토큰 및 인증 상태 초기화 확인

---

## 참고 사항
- 인증 관련 로직은 `AuthViewModel`에서 관리
- 화면 전환은 `AppNavGraph`에서 처리
- SettingsScreen에서는 이벤트만 전달하도록 유지

