### PR TITLE
[Fix] 카카오 로그인 리다이렉트/반복주기 바텀시트 크래시/말일 표시 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,10 +8,11 @@
 /.idea/navEditor.xml
 /.idea/assetWizardSettings.xml
 .DS_Store
-/build
+  /build
 /captures
 .externalNativeBuild
 .cxx
 local.properties
 .idea/
 *.iml
+ki

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,10 +34,20 @@
             android:screenOrientation="landscape"
             android:exported="false" />
 
+        <!-- Kakao web login redirect handler -->
         <activity
-            android:name=".ui.features.settings.SettingsActivity"
-            android:screenOrientation="landscape"
-            android:exported="false" />
+            android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
+            android:exported="true"
+            android:launchMode="singleTask">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="kakaob81add2e841a814fe764875a967552fe"
+                    android:host="oauth" />
+            </intent-filter>
+        </activity>
 
     </application>
 

--- a/app/src/main/java/com/example/aac/ui/features/auto_sentence/AutoSentenceAddEditScreen.kt
+++ b/app/src/main/java/com/example/aac/ui/features/auto_sentence/AutoSentenceAddEditScreen.kt
@@ -11,8 +11,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.aac.R
-import com.example.aac.ui.components.CustomTopBar
 import com.example.aac.ui.components.CommonDeleteDialog
+import com.example.aac.ui.components.CustomTopBar
 import com.example.aac.ui.features.auto_sentence.repeat.*
 import com.example.aac.ui.features.auto_sentence.time.TimePickerBottomSheet
 import com.example.aac.ui.features.auto_sentence.time.TimeState
@@ -26,44 +26,30 @@ fun AutoSentenceAddEditScreen(
     onSave: (AutoSentenceItem) -> Unit,
     onDelete: (() -> Unit)? = null
 ) {
-
     /* ---------- 초기 상태 ---------- */
-    var sentence by rememberSaveable {
-        mutableStateOf(initialItem?.sentence ?: "")
-    }
+    var sentence by rememberSaveable { mutableStateOf(initialItem?.sentence ?: "") }
 
     var repeatSetting by remember {
         mutableStateOf(
-            initialItem?.repeatSetting
-                ?: RepeatSetting(
-                    type = RepeatType.WEEKLY,
-                    days = setOf(
-                        Weekday.TUE,
-                        Weekday.WED,
-                        Weekday.THU
-                    )
-                )
+            initialItem?.repeatSetting ?: RepeatSetting(
+                type = RepeatType.WEEKLY,
+                days = setOf(Weekday.TUE, Weekday.WED, Weekday.THU)
+            )
         )
     }
 
     var timeState by remember {
         mutableStateOf(
-            initialItem?.timeState
-                ?: TimeState(
-                    isAm = true,
-                    hour = 9,
-                    minute = 0
-                )
+            initialItem?.timeState ?: TimeState(
+                isAm = true,
+                hour = 9,
+                minute = 0
+            )
         )
     }
 
-    var isRepeatSelected by remember {
-        mutableStateOf(initialItem != null)
-    }
-
-    var isTimeSelected by remember {
-        mutableStateOf(initialItem != null)
-    }
+    var isRepeatSelected by remember { mutableStateOf(initialItem != null) }
+    var isTimeSelected by remember { mutableStateOf(initialItem != null) }
 
     /* ---------- BottomSheet / Dialog 상태 ---------- */
     var showRepeatSheet by remember { mutableStateOf(false) }
@@ -87,20 +73,11 @@ fun AutoSentenceAddEditScreen(
     }
 
     /* ---------- 타이틀 ---------- */
-    val titleText = if (mode == AutoSentenceMode.ADD) {
-        "문장 추가"
-    } else {
-        "문장 편집"
-    }
+    val titleText = if (mode == AutoSentenceMode.ADD) "문장 추가" else "문장 편집"
 
-    val isFormValid =
-        sentence.isNotBlank() && isRepeatSelected && isTimeSelected
+    val isFormValid = sentence.isNotBlank() && isRepeatSelected && isTimeSelected
 
-    val saveButtonColor = if (isFormValid) {
-        Color(0xFF1C63A8)
-    } else {
-        Color(0xFFB0B0B0)
-    }
+    val saveButtonColor = if (isFormValid) Color(0xFF1C63A8) else Color(0xFFB0B0B0)
 
     /* ---------- UI ---------- */
     Scaffold(
@@ -109,7 +86,6 @@ fun AutoSentenceAddEditScreen(
             CustomTopBar(
                 title = titleText,
                 onBackClick = onBack,
-
                 actionText = "저장하기",
                 actionColor = saveButtonColor,
                 onActionClick = {
@@ -132,7 +108,6 @@ fun AutoSentenceAddEditScreen(
                 .padding(innerPadding)
                 .padding(horizontal = 24.dp)
         ) {
-
             Spacer(modifier = Modifier.height(24.dp))
 
             AutoSentenceInputField(
@@ -146,7 +121,6 @@ fun AutoSentenceAddEditScreen(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(12.dp)
             ) {
-
                 AutoSentenceOptionCard(
                     modifier = Modifier.weight(1f),
                     iconRes = R.drawable.ic_recycle,
@@ -167,19 +141,15 @@ fun AutoSentenceAddEditScreen(
             /* ---------- 삭제 버튼 (EDIT 모드에서만) ---------- */
             if (mode == AutoSentenceMode.EDIT && onDelete != null) {
                 Spacer(modifier = Modifier.height(32.dp))
-
-                DeleteButton(
-                    onClick = {
-                        showDeleteConfirmDialog = true
-                    }
-                )
+                DeleteButton(onClick = { showDeleteConfirmDialog = true })
             }
         }
 
         /* ---------- Repeat BottomSheet ---------- */
+        // 여기 수정: 바깥 터치 dismiss 시에도 안전하게 닫히도록
         if (showRepeatSheet) {
             RepeatCycleBottomSheet(
-                onDismiss = { showRepeatSheet = false },
+                onDismiss = { showRepeatSheet = false }, // BottomSheet 내부에서 hide 후 호출되게 바꾸는 게 핵심(RepeatCycleBottomSheet.kt에서 수정)
                 onComplete = { newSetting ->
                     repeatSetting = newSetting
                     isRepeatSelected = true

--- a/app/src/main/java/com/example/aac/ui/features/auto_sentence/repeat/MonthlyDayCell.kt
+++ b/app/src/main/java/com/example/aac/ui/features/auto_sentence/repeat/MonthlyDayCell.kt
@@ -1,7 +1,6 @@
 package com.example.aac.ui.features.auto_sentence.repeat
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
@@ -21,6 +20,8 @@ fun MonthlyDayCell(
     selected: Boolean,
     onClick: () -> Unit
 ) {
+    val label = if (day == 31) "말일" else day.toString()
+
     Box(
         modifier = Modifier
             .size(39.dp)
@@ -32,11 +33,10 @@ fun MonthlyDayCell(
         contentAlignment = Alignment.Center
     ) {
         Text(
-            text = day.toString(),
-            fontSize = 16.sp,
+            text = label,
+            fontSize = if (day == 31) 17.88.sp else 16.sp,
             fontWeight = FontWeight.Medium,
             color = if (selected) Color.White else Color(0xFF2C2C2C)
         )
     }
 }
-

--- a/app/src/main/java/com/example/aac/ui/features/auto_sentence/repeat/RepeatCycleBottomSheet.kt
+++ b/app/src/main/java/com/example/aac/ui/features/auto_sentence/repeat/RepeatCycleBottomSheet.kt
@@ -47,7 +47,7 @@ fun RepeatCycleBottomSheet(
     }
 
     ModalBottomSheet(
-        onDismissRequest = {},
+        onDismissRequest = { onDismiss() },
         sheetState = sheetState,
         dragHandle = null,
         containerColor = Color.Transparent


### PR DESCRIPTION
## 변경 사항
- 카카오 로그인 플로우 리다이렉트/네비게이션 흐름 문제 수정
- 루틴(매월) 출력 UI에서 31일 대신 “말일” 텍스트로 표시되도록 수정
- 반복주기 설정 BottomSheet에서 바깥 영역 터치 시 발생하던 크래시 수정 (onDismissRequest → onDismiss() 호출)

## 테스트
- 카카오 로그인 → 기존/신규 플로우 정상 이동 확인
- “매월” 선택 시 “말일” 텍스트 정상 표시 확인
- 반복주기 BottomSheet 바깥 터치/닫기(X)로 종료 시 크래시 없는지 확인