### PR TITLE
[AutoSentence] 전역 Routine Modal Polling 적용 및 자동 출력 문장 설정 부분 API 전체 연결 및 상태 관리 리팩토링

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
     implementation(libs.androidx.compose.foundation)
     implementation(libs.androidx.ui)
     implementation(libs.androidx.runtime)
+    implementation(libs.androidx.foundation)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/java/com/example/aac/core/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/example/aac/core/navigation/AppNavGraph.kt
@@ -36,30 +36,47 @@ import com.example.aac.ui.features.voice_setting.VoiceSettingScreen
 fun AppNavGraph() {
 
     val navController = rememberNavController()
-
-    /* ---------- AuthViewModel 단일 생성 ---------- */
     val authViewModel: AuthViewModel = viewModel()
-
-    /* ---------- 목소리 설정 선택 상태 ---------- */
-    var voiceSettingId by remember { mutableStateOf("default_male") }
-
-    /* ---------- 루틴 API(ViewModel) 공용 ---------- */
     val routineVm: AutoSentenceRoutineViewModel = viewModel()
 
-    /* ---------- 🔥 전역 모달 상태 구독 ---------- */
-    val modalRoutine by routineVm.modalRoutine.collectAsState()
+    var voiceSettingId by remember { mutableStateOf("default_male") }
 
-    /* ---------- 🔥 1분 polling (앱 켜져있는 동안만) ---------- */
-    LaunchedEffect(Unit) {
-        while (true) {
-            routineVm.checkRoutineModal()
-            delay(60_000)
+    val modalRoutine by routineVm.modalRoutine.collectAsState()
+    val logoutCompleted by authViewModel.logoutCompleted.collectAsState()
+    val withdrawCompleted by authViewModel.withdrawCompleted.collectAsState()
+
+    /* ---------- 🔥 로그인 상태일 때만 1분 polling ---------- */
+    val loginState by authViewModel.loginState.collectAsState()
+
+    LaunchedEffect(loginState) {
+        if (loginState != null) {
+            while (loginState != null) {
+                routineVm.checkRoutineModal()
+                delay(60_000)
+            }
         }
     }
 
+    /* ---------- 🔥 로그아웃 처리 ---------- */
+    LaunchedEffect(logoutCompleted) {
+        if (logoutCompleted) {
+            navController.navigate(Routes.LOGIN) {
+                popUpTo(0) { inclusive = true }
+            }
+            authViewModel.consumeLogoutCompleted()
+        }
+    }
 
+    /* ---------- 🔥 회원탈퇴 처리 ---------- */
+    LaunchedEffect(withdrawCompleted) {
+        if (withdrawCompleted) {
+            navController.navigate(Routes.LOGIN) {
+                popUpTo(0) { inclusive = true }
+            }
+            authViewModel.consumeWithdrawCompleted()
+        }
+    }
 
-    /* ---------- 🔥 전체를 Box로 감싸서 전역 오버레이 가능 ---------- */
     Box(modifier = Modifier.fillMaxSize()) {
 
         NavHost(
@@ -281,6 +298,7 @@ fun AppNavGraph() {
 
             /* ---------- AUTO SENTENCE SELECT DELETE ---------- */
             composable(Routes.AUTO_SENTENCE_SELECT_DELETE) {
+
                 val routineUiState by routineVm.uiState.collectAsState()
 
                 val items = routineUiState.routines.map {
@@ -303,6 +321,8 @@ fun AppNavGraph() {
                 )
             }
 
+
+
             /* ---------- CATEGORY MANAGEMENT ---------- */
             composable(Routes.CATEGORY_MANAGEMENT) {
                 CategoryManagementScreen(
@@ -318,9 +338,9 @@ fun AppNavGraph() {
             }
         }
 
-        /* ---------- 🔥 전역 모달 오버레이 ---------- */
+        /* ---------- 전역 모달 ---------- */
         modalRoutine?.let { routine ->
-            Log.d("MODAL", "🔥 현재 모달 routine id = ${routine.id}")
+            Log.d("MODAL", "🔥 모달 routine id = ${routine.id}")
 
             RoutineModal(
                 routine = routine,
@@ -332,6 +352,5 @@ fun AppNavGraph() {
                 }
             )
         }
-
     }
 }

--- a/app/src/main/java/com/example/aac/core/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/example/aac/core/navigation/AppNavGraph.kt
@@ -1,14 +1,18 @@
 package com.example.aac.core.navigation
 
 import android.content.Intent
+import android.util.Log
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavType
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.rememberNavController
+import androidx.navigation.compose.*
 import androidx.navigation.navArgument
+import kotlinx.coroutines.delay
+
 import com.example.aac.data.mapper.toAutoSentenceItem
 import com.example.aac.data.mapper.toCreateRoutineRequest
 import com.example.aac.data.mapper.toRoutineUpdateRequest
@@ -17,6 +21,7 @@ import com.example.aac.ui.features.ai_sentence.ui.AiSentenceEditScreen
 import com.example.aac.ui.features.ai_sentence.ui.AiSentenceScreen
 import com.example.aac.ui.features.auth.AuthViewModel
 import com.example.aac.ui.features.auto_sentence.*
+import com.example.aac.ui.features.auto_sentence.components.RoutineModal
 import com.example.aac.ui.features.category.CategoryManagementScreen
 import com.example.aac.ui.features.main.MainScreen
 import com.example.aac.ui.features.settings.SettingsScreen
@@ -29,6 +34,7 @@ import com.example.aac.ui.features.voice_setting.VoiceSettingScreen
 
 @Composable
 fun AppNavGraph() {
+
     val navController = rememberNavController()
 
     /* ---------- AuthViewModel 단일 생성 ---------- */
@@ -40,298 +46,292 @@ fun AppNavGraph() {
     /* ---------- 루틴 API(ViewModel) 공용 ---------- */
     val routineVm: AutoSentenceRoutineViewModel = viewModel()
 
-    NavHost(
-        navController = navController,
-        startDestination = Routes.LOGIN
-    ) {
+    /* ---------- 🔥 전역 모달 상태 구독 ---------- */
+    val modalRoutine by routineVm.modalRoutine.collectAsState()
 
-        /* ---------- LOGIN ---------- */
-        composable(Routes.LOGIN) {
-            LoginRoute(
-                viewModel = authViewModel,
-                onNavigateToTerms = {
-                    navController.navigate(Routes.TERMS) { launchSingleTop = true }
-                },
-                onNavigateToMain = {
-                    navController.navigate(Routes.MAIN) {
-                        popUpTo(Routes.LOGIN) { inclusive = true }
-                        launchSingleTop = true
-                    }
-                }
-            )
+    /* ---------- 🔥 1분 polling (앱 켜져있는 동안만) ---------- */
+    LaunchedEffect(Unit) {
+        while (true) {
+            routineVm.checkRoutineModal()
+            delay(60_000)
         }
+    }
 
-        /* ---------- TERMS ---------- */
-        composable(Routes.TERMS) {
-            val signupCompleted by authViewModel.signupCompleted.collectAsState()
 
-            LaunchedEffect(signupCompleted) {
-                if (signupCompleted) {
-                    navController.navigate(Routes.MAIN) {
-                        popUpTo(Routes.TERMS) { inclusive = true }
-                        launchSingleTop = true
+
+    /* ---------- 🔥 전체를 Box로 감싸서 전역 오버레이 가능 ---------- */
+    Box(modifier = Modifier.fillMaxSize()) {
+
+        NavHost(
+            navController = navController,
+            startDestination = Routes.LOGIN
+        ) {
+
+            /* ---------- LOGIN ---------- */
+            composable(Routes.LOGIN) {
+                LoginRoute(
+                    viewModel = authViewModel,
+                    onNavigateToTerms = {
+                        navController.navigate(Routes.TERMS)
+                    },
+                    onNavigateToMain = {
+                        navController.navigate(Routes.MAIN) {
+                            popUpTo(Routes.LOGIN) { inclusive = true }
+                        }
                     }
-                    authViewModel.resetSignupState()
-                }
+                )
             }
 
-            TermsScreen(
-                navController = navController,
-                authViewModel = authViewModel,
-                onBackClick = {
-                    authViewModel.cancelSignupFlow()
-                    navController.navigate(Routes.LOGIN) {
-                        popUpTo(Routes.TERMS) { inclusive = true }
-                        launchSingleTop = true
+            /* ---------- TERMS ---------- */
+            composable(Routes.TERMS) {
+                val signupCompleted by authViewModel.signupCompleted.collectAsState()
+
+                LaunchedEffect(signupCompleted) {
+                    if (signupCompleted) {
+                        navController.navigate(Routes.MAIN) {
+                            popUpTo(Routes.TERMS) { inclusive = true }
+                        }
+                        authViewModel.resetSignupState()
                     }
                 }
-            )
-        }
 
-        /* ---------- TERMS DETAIL ---------- */
-        composable(
-            route = "terms_detail/{termId}",
-            arguments = listOf(navArgument("termId") { type = NavType.StringType })
-        ) { backStackEntry ->
-            val termId = backStackEntry.arguments?.getString("termId") ?: ""
-            TermsDetailScreen(
-                termId = termId,
-                authViewModel = authViewModel,
-                navController = navController
-            )
-        }
-
-        /* ---------- MAIN ---------- */
-        composable(Routes.MAIN) {
-            MainScreen(
-                onNavigateToAiSentence = { navController.navigate(Routes.AI_SENTENCE) },
-                onNavigateToSettings = { navController.navigate(Routes.SETTINGS) }
-            )
-        }
-
-        /* ---------- SETTINGS ---------- */
-        composable(Routes.SETTINGS) {
-            val context = LocalContext.current
-
-            val logoutCompleted by authViewModel.logoutCompleted.collectAsState()
-            val withdrawCompleted by authViewModel.withdrawCompleted.collectAsState()
-
-            LaunchedEffect(logoutCompleted) {
-                if (logoutCompleted) {
-                    navController.navigate(Routes.LOGIN) {
-                        popUpTo(Routes.LOGIN) { inclusive = true }
-                        launchSingleTop = true
+                TermsScreen(
+                    navController = navController,
+                    authViewModel = authViewModel,
+                    onBackClick = {
+                        authViewModel.cancelSignupFlow()
+                        navController.navigate(Routes.LOGIN) {
+                            popUpTo(Routes.TERMS) { inclusive = true }
+                        }
                     }
-                    authViewModel.consumeLogoutCompleted()
-                }
+                )
             }
 
-            LaunchedEffect(withdrawCompleted) {
-                if (withdrawCompleted) {
-                    navController.navigate(Routes.LOGIN) {
-                        popUpTo(Routes.LOGIN) { inclusive = true }
-                        launchSingleTop = true
-                    }
-                    authViewModel.consumeWithdrawCompleted()
-                }
+            /* ---------- TERMS DETAIL ---------- */
+            composable(
+                route = "terms_detail/{termId}",
+                arguments = listOf(navArgument("termId") { type = NavType.StringType })
+            ) { backStackEntry ->
+                val termId = backStackEntry.arguments?.getString("termId") ?: ""
+                TermsDetailScreen(
+                    termId = termId,
+                    authViewModel = authViewModel,
+                    navController = navController
+                )
             }
 
-            SettingsScreen(
-                authViewModel = authViewModel,
-                onBackClick = { navController.popBackStack() },
-                onAutoSentenceSettingClick = { navController.navigate(Routes.AUTO_SENTENCE_SETTING) },
-                onVoiceSettingClick = { navController.navigate(Routes.VOICE_SETTING) },
-                onUsageHistoryClick = {
-                    val intent = Intent(context, UsageHistoryActivity::class.java)
-                    context.startActivity(intent)
-                },
-                onCategoryManagementClick = { navController.navigate(Routes.CATEGORY_MANAGEMENT) },
-                onSpeakSettingClick = { navController.navigate(Routes.SPEAK_SETTING) }
-            )
-        }
+            /* ---------- MAIN ---------- */
+            composable(Routes.MAIN) {
+                MainScreen(
+                    onNavigateToAiSentence = {
+                        navController.navigate(Routes.AI_SENTENCE)
+                    },
+                    onNavigateToSettings = {
+                        navController.navigate(Routes.SETTINGS)
+                    }
+                )
+            }
 
-        /* ---------- VOICE SETTING ---------- */
-        composable(Routes.VOICE_SETTING) {
-            VoiceSettingScreen(
-                initialSelectedId = voiceSettingId,
-                onBackClick = { navController.popBackStack() },
-                onSave = { selectedId -> voiceSettingId = selectedId }
-            )
-        }
+            /* ---------- SETTINGS ---------- */
+            composable(Routes.SETTINGS) {
+                val context = LocalContext.current
 
-        /* ---------- AI SENTENCE ---------- */
-        composable(Routes.AI_SENTENCE) {
-            AiSentenceScreen(
-                initialWords = SentenceDataRepository.selectedWords,
-                onBack = { navController.popBackStack() },
-                onEditNavigate = { text ->
-                    navController.navigate(Routes.aiSentenceEditRoute(text))
-                }
-            )
-        }
+                SettingsScreen(
+                    authViewModel = authViewModel,
+                    onBackClick = { navController.popBackStack() },
+                    onAutoSentenceSettingClick = {
+                        navController.navigate(Routes.AUTO_SENTENCE_SETTING)
+                    },
+                    onVoiceSettingClick = {
+                        navController.navigate(Routes.VOICE_SETTING)
+                    },
+                    onUsageHistoryClick = {
+                        val intent = Intent(context, UsageHistoryActivity::class.java)
+                        context.startActivity(intent)
+                    },
+                    onCategoryManagementClick = {
+                        navController.navigate(Routes.CATEGORY_MANAGEMENT)
+                    },
+                    onSpeakSettingClick = {
+                        navController.navigate(Routes.SPEAK_SETTING)
+                    }
+                )
+            }
 
-        /* ---------- AI SENTENCE EDIT ---------- */
-        composable(
-            route = Routes.AI_SENTENCE_EDIT_ROUTE,
-            arguments = listOf(
-                navArgument("text") {
+            /* ---------- VOICE SETTING ---------- */
+            composable(Routes.VOICE_SETTING) {
+                VoiceSettingScreen(
+                    initialSelectedId = voiceSettingId,
+                    onBackClick = { navController.popBackStack() },
+                    onSave = { selectedId -> voiceSettingId = selectedId }
+                )
+            }
+
+            /* ---------- AI SENTENCE ---------- */
+            composable(Routes.AI_SENTENCE) {
+                AiSentenceScreen(
+                    initialWords = SentenceDataRepository.selectedWords,
+                    onBack = { navController.popBackStack() },
+                    onEditNavigate = { text ->
+                        navController.navigate(Routes.aiSentenceEditRoute(text))
+                    }
+                )
+            }
+
+            /* ---------- AI SENTENCE EDIT ---------- */
+            composable(
+                route = Routes.AI_SENTENCE_EDIT_ROUTE,
+                arguments = listOf(navArgument("text") {
                     type = NavType.StringType
                     defaultValue = ""
-                }
-            )
-        ) { backStackEntry ->
-            val text = backStackEntry.arguments?.getString("text").orEmpty()
-            AiSentenceEditScreen(
-                initialText = text,
-                onBack = { navController.popBackStack() }
-            )
-        }
-
-        /* ---------- AUTO SENTENCE SETTING ---------- */
-        composable(Routes.AUTO_SENTENCE_SETTING) {
-
-            AutoSentenceSettingScreen(
-                onBack = { navController.popBackStack() },
-
-                onAddClick = {
-                    navController.navigate(Routes.AUTO_SENTENCE_ADD)
-                },
-
-                onEditClick = { item ->
-                    navController.navigate(
-                        Routes.autoSentenceEditRoute(item.serverId)
-                    )
-                },
-
-                onSelectDeleteClick = {
-                    navController.navigate(Routes.AUTO_SENTENCE_SELECT_DELETE)
-                },
-
-                routineViewModel = routineVm,
-                routineToItem = { dto -> dto.toAutoSentenceItem() }
-            )
-        }
-
-
-
-        /* ---------- AUTO SENTENCE ADD ---------- */
-        composable(Routes.AUTO_SENTENCE_ADD) {
-            AutoSentenceAddEditScreen(
-                mode = AutoSentenceMode.ADD,
-                initialItem = null,
-                onBack = { navController.popBackStack() },
-                onSave = { item ->
-                    routineVm.createRoutine(
-                        request = item.toCreateRoutineRequest(),
-                        onSuccess = { navController.popBackStack() }
-                    )
-                }
-            )
-        }
-
-        /* ---------- AUTO SENTENCE EDIT ---------- */
-        composable(
-            route = Routes.AUTO_SENTENCE_EDIT,
-            arguments = listOf(navArgument("serverId") { type = NavType.StringType })
-        ) { backStackEntry ->
-
-            val serverId = backStackEntry.arguments?.getString("serverId").orEmpty()
-            val routineUiState by routineVm.uiState.collectAsState()
-
-            LaunchedEffect(serverId) {
-                if (routineUiState.routines.isEmpty()) {
-                    routineVm.fetchRoutines()
-                }
+                })
+            ) { backStackEntry ->
+                val text = backStackEntry.arguments?.getString("text").orEmpty()
+                AiSentenceEditScreen(
+                    initialText = text,
+                    onBack = { navController.popBackStack() }
+                )
             }
 
-            val serverItems = remember(routineUiState.routines) {
-                routineUiState.routines.map { it.toAutoSentenceItem() }
-            }
-
-            val targetItem = remember(serverId, serverItems) {
-                serverItems.find { it.serverId == serverId }
-            }
-
-            if (targetItem != null) {
-
-                AutoSentenceAddEditScreen(
-                    mode = AutoSentenceMode.EDIT,
-                    initialItem = targetItem,
-
+            /* ---------- AUTO SENTENCE SETTING ---------- */
+            composable(Routes.AUTO_SENTENCE_SETTING) {
+                AutoSentenceSettingScreen(
                     onBack = { navController.popBackStack() },
-
-                    onSave = { updatedItem ->
-                        routineVm.updateRoutine(
-                            id = targetItem.serverId,
-                            request = updatedItem.copy(
-                                id = targetItem.id,
-                                serverId = targetItem.serverId
-                            ).toRoutineUpdateRequest(),
-                            onSuccess = {
-                                navController.popBackStack()
-                            }
+                    onAddClick = {
+                        navController.navigate(Routes.AUTO_SENTENCE_ADD)
+                    },
+                    onEditClick = { item ->
+                        navController.navigate(
+                            Routes.autoSentenceEditRoute(item.serverId)
                         )
                     },
-                    onDelete = {
-                        routineVm.deleteRoutine(
-                            id = targetItem.serverId,
-                            onSuccess = {
-                                navController.navigate(Routes.AUTO_SENTENCE_SETTING) {
-                                    popUpTo(Routes.AUTO_SENTENCE_SETTING) {
-                                        inclusive = false
-                                    }
-                                    launchSingleTop = true
-                                }
-                            }
+                    onSelectDeleteClick = {
+                        navController.navigate(Routes.AUTO_SENTENCE_SELECT_DELETE)
+                    },
+                    routineViewModel = routineVm,
+                    routineToItem = { dto -> dto.toAutoSentenceItem() }
+                )
+            }
+
+            /* ---------- AUTO SENTENCE ADD ---------- */
+            composable(Routes.AUTO_SENTENCE_ADD) {
+                AutoSentenceAddEditScreen(
+                    mode = AutoSentenceMode.ADD,
+                    initialItem = null,
+                    onBack = { navController.popBackStack() },
+                    onSave = { item ->
+                        routineVm.createRoutine(
+                            request = item.toCreateRoutineRequest(),
+                            onSuccess = { navController.popBackStack() }
                         )
                     }
-
                 )
+            }
 
-            } else {
-                LaunchedEffect(routineUiState.isLoading, routineUiState.routines) {
-                    if (!routineUiState.isLoading && routineUiState.routines.isNotEmpty()) {
-                        navController.popBackStack()
+            /* ---------- AUTO SENTENCE EDIT ---------- */
+            composable(
+                route = Routes.AUTO_SENTENCE_EDIT,
+                arguments = listOf(navArgument("serverId") { type = NavType.StringType })
+            ) { backStackEntry ->
+
+                val serverId = backStackEntry.arguments?.getString("serverId").orEmpty()
+                val routineUiState by routineVm.uiState.collectAsState()
+
+                LaunchedEffect(serverId) {
+                    if (routineUiState.routines.isEmpty()) {
+                        routineVm.fetchRoutines()
                     }
                 }
-            }
-        }
 
-        /* ---------- AUTO SENTENCE SELECT DELETE ---------- */
-        composable(Routes.AUTO_SENTENCE_SELECT_DELETE) {
+                val serverItems = routineUiState.routines.map {
+                    it.toAutoSentenceItem()
+                }
 
-            val routineUiState by routineVm.uiState.collectAsState()
+                val targetItem = serverItems.find {
+                    it.serverId == serverId
+                }
 
-            val items = remember(routineUiState.routines) {
-                routineUiState.routines.map { it.toAutoSentenceItem() }
-            }
-            AutoSentenceSelectDeleteScreen(
-                autoSentenceList = items,
-                onBack = {
-                    navController.popBackStack()
-                },
-                onDeleteSelected = { selectedUiIds ->
-                    val selectedServerIds = items
-                        .filter { selectedUiIds.contains(it.id) }
-                        .map { it.serverId }
-                    routineVm.deleteRoutines(
-                        ids = selectedServerIds,
-                        onSuccess = {
-                            navController.popBackStack()
+                targetItem?.let {
+                    AutoSentenceAddEditScreen(
+                        mode = AutoSentenceMode.EDIT,
+                        initialItem = it,
+                        onBack = { navController.popBackStack() },
+                        onSave = { updatedItem ->
+                            routineVm.updateRoutine(
+                                id = it.serverId,
+                                request = updatedItem.toRoutineUpdateRequest(),
+                                onSuccess = { navController.popBackStack() }
+                            )
+                        },
+                        onDelete = {
+                            routineVm.deleteRoutine(
+                                id = it.serverId,
+                                onSuccess = {
+                                    navController.navigate(Routes.AUTO_SENTENCE_SETTING) {
+                                        popUpTo(Routes.AUTO_SENTENCE_SETTING) {
+                                            inclusive = false
+                                        }
+                                    }
+                                }
+                            )
                         }
                     )
                 }
+            }
+
+            /* ---------- AUTO SENTENCE SELECT DELETE ---------- */
+            composable(Routes.AUTO_SENTENCE_SELECT_DELETE) {
+                val routineUiState by routineVm.uiState.collectAsState()
+
+                val items = routineUiState.routines.map {
+                    it.toAutoSentenceItem()
+                }
+
+                AutoSentenceSelectDeleteScreen(
+                    autoSentenceList = items,
+                    onBack = { navController.popBackStack() },
+                    onDeleteSelected = { selectedUiIds ->
+                        val selectedServerIds = items
+                            .filter { selectedUiIds.contains(it.id) }
+                            .map { it.serverId }
+
+                        routineVm.deleteRoutines(
+                            ids = selectedServerIds,
+                            onSuccess = { navController.popBackStack() }
+                        )
+                    }
+                )
+            }
+
+            /* ---------- CATEGORY MANAGEMENT ---------- */
+            composable(Routes.CATEGORY_MANAGEMENT) {
+                CategoryManagementScreen(
+                    onBackClick = { navController.popBackStack() }
+                )
+            }
+
+            /* ---------- SPEAK SETTING ---------- */
+            composable(Routes.SPEAK_SETTING) {
+                SpeakSettingScreen(
+                    onBackClick = { navController.popBackStack() }
+                )
+            }
+        }
+
+        /* ---------- 🔥 전역 모달 오버레이 ---------- */
+        modalRoutine?.let { routine ->
+            Log.d("MODAL", "🔥 현재 모달 routine id = ${routine.id}")
+
+            RoutineModal(
+                routine = routine,
+                onSnoozeClick = {
+                    routineVm.snoozeRoutine(routine.id)
+                },
+                onDismissClick = {
+                    routineVm.dismissRoutine(routine.id)
+                }
             )
         }
 
-        /* ---------- CATEGORY MANAGEMENT ---------- */
-        composable(Routes.CATEGORY_MANAGEMENT) {
-            CategoryManagementScreen(onBackClick = { navController.popBackStack() })
-        }
-
-        /* ---------- SPEAK SETTING ---------- */
-        composable(Routes.SPEAK_SETTING) {
-            SpeakSettingScreen(onBackClick = { navController.popBackStack() })
-        }
     }
 }

--- a/app/src/main/java/com/example/aac/core/navigation/Routes.kt
+++ b/app/src/main/java/com/example/aac/core/navigation/Routes.kt
@@ -39,11 +39,11 @@ object Routes {
     // 자동 출력 문장 추가
     const val AUTO_SENTENCE_ADD = "auto_sentence_add"
 
-    // 자동 출력 문장 편집
-    const val AUTO_SENTENCE_EDIT = "auto_sentence_edit/{itemId}"
+    // 자동 출력 문장 편집 (serverId 기반)
+    const val AUTO_SENTENCE_EDIT = "auto_sentence_edit/{serverId}"
 
-    fun autoSentenceEditRoute(itemId: Long): String =
-        "auto_sentence_edit/$itemId"
+    fun autoSentenceEditRoute(serverId: String): String =
+        "auto_sentence_edit/$serverId"
 
     // 자동 출력 문장 선택 삭제 화면
     const val AUTO_SENTENCE_SELECT_DELETE = "auto_sentence_select_delete"

--- a/app/src/main/java/com/example/aac/data/mapper/RoutineDomainMapper.kt
+++ b/app/src/main/java/com/example/aac/data/mapper/RoutineDomainMapper.kt
@@ -1,0 +1,21 @@
+package com.example.aac.data.mapper
+
+import com.example.aac.data.remote.dto.RoutineDto
+import com.example.aac.domain.model.Routine
+
+/**
+ * 서버 RoutineDto -> domain Routine 매핑
+ * (domain Routine이 실제로 받는 필드만 넣는다)
+ */
+fun RoutineDto.toDomainRoutine(): Routine {
+    return Routine(
+        id = id,
+        message = message,
+        repeatType = repeatType,
+        daysOfWeek = daysOfWeek ?: emptyList(),
+        daysOfMonth = daysOfMonth ?: emptyList(),
+        isMonthEnd = isMonthEnd,
+        scheduledTime = scheduledTime,
+        isActive = isActive
+    )
+}

--- a/app/src/main/java/com/example/aac/data/mapper/RoutineMapper.kt
+++ b/app/src/main/java/com/example/aac/data/mapper/RoutineMapper.kt
@@ -1,0 +1,155 @@
+package com.example.aac.data.mapper
+
+import com.example.aac.data.remote.dto.RoutineDto
+import com.example.aac.ui.features.auto_sentence.AutoSentenceItem
+import com.example.aac.ui.features.auto_sentence.repeat.RepeatSetting
+import com.example.aac.ui.features.auto_sentence.repeat.RepeatType
+import com.example.aac.ui.features.auto_sentence.repeat.Weekday
+import com.example.aac.ui.features.auto_sentence.time.TimeState
+import kotlin.math.abs
+import com.example.aac.data.remote.dto.RoutineUpdateRequest
+
+/**
+ * 서버 RoutineDto -> UI AutoSentenceItem 매핑
+ * - serverId: 서버 UUID(String) 그대로 보관 (PATCH/DELETE용)
+ * - id: UI에서 쓰는 안정 Long (hash 기반)
+ */
+fun RoutineDto.toAutoSentenceItem(): AutoSentenceItem {
+    return AutoSentenceItem(
+        id = id.toStableLongId(),
+        serverId = id, // ✅ 서버 id(UUID)
+        sentence = message,
+        repeatSetting = this.toRepeatSetting(),
+        timeState = scheduledTime.toTimeState()
+    )
+}
+
+/** UUID(String) -> Long (UI용) */
+private fun String.toStableLongId(): Long = abs(this.hashCode().toLong())
+
+/** "08:30" -> TimeState(isAm, hour(1~12), minute) */
+private fun String.toTimeState(): TimeState {
+    val parts = this.split(":")
+    val hour24 = parts.getOrNull(0)?.toIntOrNull() ?: 0
+    val minute = parts.getOrNull(1)?.toIntOrNull() ?: 0
+
+    val isAm = hour24 < 12
+    val hour12 = when (hour24 % 12) {
+        0 -> 12
+        else -> hour24 % 12
+    }
+
+    return TimeState(
+        isAm = isAm,
+        hour = hour12,
+        minute = minute
+    )
+}
+
+/**
+ * 서버 repeatType/daysOfWeek/daysOfMonth -> RepeatSetting 변환
+ * - daysOfWeek/daysOfMonth는 null 올 수 있어 안전처리
+ * - isMonthEnd는 UI RepeatSetting에 없어서 현재는 반영 안 함
+ */
+private fun RoutineDto.toRepeatSetting(): RepeatSetting {
+    val repeatTypeUi: RepeatType = when (repeatType.uppercase()) {
+        "DAILY" -> RepeatType.DAILY
+        "WEEKLY" -> RepeatType.WEEKLY
+        "BIWEEKLY" -> RepeatType.BIWEEKLY
+        "MONTHLY" -> RepeatType.MONTHLY
+        else -> RepeatType.WEEKLY
+    }
+
+    val weekdaysUi: Set<Weekday> = (daysOfWeek ?: emptyList())
+        .mapNotNull { it.toWeekdayOrNull() }
+        .toSet()
+
+    val monthDaysUi: Set<Int> = (daysOfMonth ?: emptyList())
+        .filter { it in 1..31 }
+        .toSet()
+
+    return RepeatSetting(
+        type = repeatTypeUi,
+        days = weekdaysUi,
+        monthDays = monthDaysUi
+    )
+}
+
+/** 서버 daysOfWeek Int -> Weekday (가정: 1=Mon ... 7=Sun) */
+private fun Int.toWeekdayOrNull(): Weekday? {
+    return when (this) {
+        1 -> Weekday.MON
+        2 -> Weekday.TUE
+        3 -> Weekday.WED
+        4 -> Weekday.THU
+        5 -> Weekday.FRI
+        6 -> Weekday.SAT
+        7 -> Weekday.SUN
+        else -> null
+    }
+}
+
+/**
+ * UI AutoSentenceItem -> 서버 RoutineUpdateRequest 변환 (PATCH용)
+ * - WEEKLY/BIWEEKLY: daysOfMonth는 null로 보내서 JSON에서 빠지게 함
+ * - MONTHLY: daysOfWeek는 null로 보내서 JSON에서 빠지게 함
+ * - MONTHLY에서 31은 "말일"로 쓸 수도 있어서 isMonthEnd로 분리
+ */
+fun AutoSentenceItem.toRoutineUpdateRequest(): RoutineUpdateRequest {
+    val type = repeatSetting.type.name // DAILY/WEEKLY/BIWEEKLY/MONTHLY
+
+    // ✅ 요일: 주/격주만 보냄 (그 외는 null)
+    val daysOfWeek: List<Int>? =
+        if (type == "WEEKLY" || type == "BIWEEKLY") repeatSetting.days.toServerDaysOfWeek()
+        else null
+
+    // ✅ 말일 처리(31을 말일로 쓰는 케이스)
+    val isMonthEnd = (type == "MONTHLY") && repeatSetting.monthDays.contains(31)
+
+    // ✅ 날짜: 월간만 보냄 (그 외는 null)
+    // - 31을 말일로 쓰면 서버가 따로 받는다면 daysOfMonth에서는 빼주는 게 안전
+    val daysOfMonth: List<Int>? =
+        if (type == "MONTHLY") {
+            val filtered = repeatSetting.monthDays
+                .filter { it in 1..31 }
+                .filterNot { it == 31 && isMonthEnd }
+                .toList()
+
+            // 서버가 "최소 1개" 강제면, 말일(isMonthEnd=true)만 선택한 경우 filtered가 비게 됨
+            // -> 그땐 null 대신 emptyList()가 아니라, isMonthEnd=true로 보내고 daysOfMonth는 null로 빼는 게 보통 맞음
+            // (서버가 isMonthEnd만으로 허용해야 정상)
+            if (filtered.isEmpty() && !isMonthEnd) null else filtered
+        } else null
+
+    return RoutineUpdateRequest(
+        message = sentence,
+        scheduledTime = timeState.toServerTimeString(),
+        repeatType = type,
+        daysOfWeek = daysOfWeek,
+        daysOfMonth = daysOfMonth,
+        isMonthEnd = isMonthEnd
+    )
+}
+
+private fun TimeState.toServerTimeString(): String {
+    val hour24 = if (isAm) {
+        if (hour == 12) 0 else hour
+    } else {
+        if (hour == 12) 12 else hour + 12
+    }
+    return "%02d:%02d".format(hour24, minute)
+}
+
+private fun Set<Weekday>.toServerDaysOfWeek(): List<Int> {
+    return this.map {
+        when (it) {
+            Weekday.MON -> 1
+            Weekday.TUE -> 2
+            Weekday.WED -> 3
+            Weekday.THU -> 4
+            Weekday.FRI -> 5
+            Weekday.SAT -> 6
+            Weekday.SUN -> 7
+        }
+    }.sorted()
+}

--- a/app/src/main/java/com/example/aac/data/mapper/RoutineRequestMapper.kt
+++ b/app/src/main/java/com/example/aac/data/mapper/RoutineRequestMapper.kt
@@ -1,0 +1,54 @@
+package com.example.aac.data.mapper
+
+import com.example.aac.data.remote.dto.CreateRoutineRequest
+import com.example.aac.ui.features.auto_sentence.AutoSentenceItem
+import com.example.aac.ui.features.auto_sentence.repeat.RepeatType
+import com.example.aac.ui.features.auto_sentence.repeat.Weekday
+import com.example.aac.ui.features.auto_sentence.time.TimeState
+
+fun AutoSentenceItem.toCreateRoutineRequest(): CreateRoutineRequest {
+    val scheduledTime = timeState.toScheduledTimeString()
+
+    val daysOfWeek = when (repeatSetting.type) {
+        RepeatType.WEEKLY, RepeatType.BIWEEKLY -> repeatSetting.days.map { it.toServerDayOfWeek() }
+        else -> emptyList()
+    }
+
+    val daysOfMonth = when (repeatSetting.type) {
+        RepeatType.MONTHLY -> repeatSetting.monthDays.toList()
+        else -> emptyList()
+    }
+
+    val isMonthEnd = repeatSetting.type == RepeatType.MONTHLY && repeatSetting.monthDays.contains(31)
+
+    return CreateRoutineRequest(
+        message = sentence,
+        scheduledTime = scheduledTime,
+        repeatType = repeatSetting.type.name, // DAILY/WEEKLY/BIWEEKLY/MONTHLY
+        daysOfWeek = daysOfWeek,
+        daysOfMonth = daysOfMonth.filter { it in 1..31 },
+        isMonthEnd = isMonthEnd
+    )
+}
+
+private fun TimeState.toScheduledTimeString(): String {
+    val hour24 = when {
+        isAm && hour == 12 -> 0
+        !isAm && hour == 12 -> 12
+        !isAm -> hour + 12
+        else -> hour
+    }
+    return "${hour24.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}"
+}
+
+private fun Weekday.toServerDayOfWeek(): Int {
+    return when (this) {
+        Weekday.MON -> 1
+        Weekday.TUE -> 2
+        Weekday.WED -> 3
+        Weekday.THU -> 4
+        Weekday.FRI -> 5
+        Weekday.SAT -> 6
+        Weekday.SUN -> 7
+    }
+}

--- a/app/src/main/java/com/example/aac/data/remote/api/AacApiService.kt
+++ b/app/src/main/java/com/example/aac/data/remote/api/AacApiService.kt
@@ -5,9 +5,15 @@ import retrofit2.http.*
 
 interface AacApiService {
 
+    // ----------------------------------------------------
+    // [Auth]
+    // ----------------------------------------------------
+
     // [Auth] 게스트 로그인
     @POST("api/auth/guest")
-    suspend fun createGuestAccount(@Body request: GuestLoginRequest): GuestLoginResponse
+    suspend fun createGuestAccount(
+        @Body request: GuestLoginRequest
+    ): GuestLoginResponse
 
     // [Auth] 내 정보 조회
     @GET("api/auth/me")
@@ -21,9 +27,6 @@ interface AacApiService {
     @DELETE("api/auth/account")
     suspend fun withdraw(): BaseResponse<Unit>
 
-    // ----------------------------------------------------
-    // 🔥 [Main] 단어 목록 조회 (여기가 중요!)
-    // ----------------------------------------------------
     // [Auth] 카카오 SDK 로그인
     @POST("api/auth/kakao/sdk")
     suspend fun kakaoLogin(
@@ -41,6 +44,10 @@ interface AacApiService {
     suspend fun getTerms(): BaseResponse<List<TermsResponse>>
 
 
+    // ----------------------------------------------------
+    // [Main]
+    // ----------------------------------------------------
+
     // [Main] 단어 목록 조회
     @GET("api/words")
     suspend fun getWords(
@@ -48,28 +55,44 @@ interface AacApiService {
         @Query("onlyFavorite") onlyFavorite: Boolean? = null
     ): WordResponse
 
+
+    // ----------------------------------------------------
+    // [Category]
+    // ----------------------------------------------------
+
     // [Category] 카테고리 목록 조회
     @GET("api/categories")
     suspend fun getCategories(): BaseResponse<List<CategoryResponse>>
 
-    // 카테고리 생성
+    // [Category] 카테고리 생성
     @POST("api/categories")
-    suspend fun createCategory(@Body request: CreateCategoryRequest): BaseResponse<CategoryResponse>
+    suspend fun createCategory(
+        @Body request: CreateCategoryRequest
+    ): BaseResponse<CategoryResponse>
 
-    // 카테고리 수정
+    // [Category] 카테고리 수정
     @PATCH("api/categories/{id}")
     suspend fun updateCategory(
         @Path("id") id: String,
         @Body request: UpdateCategoryRequest
     ): BaseResponse<CategoryResponse>
 
-    // 카테고리 삭제
+    // [Category] 카테고리 삭제
     @DELETE("api/categories/{id}")
-    suspend fun deleteCategory(@Path("id") id: String): BaseResponse<DeleteCategoryResponse>
+    suspend fun deleteCategory(
+        @Path("id") id: String
+    ): BaseResponse<DeleteCategoryResponse>
 
-    // 카테고리 순서 변경
+    // [Category] 카테고리 순서 변경
     @PATCH("api/order/categories")
-    suspend fun updateCategoryOrders(@Body request: CategoryOrderRequest): BaseResponse<CategoryResponse>
+    suspend fun updateCategoryOrders(
+        @Body request: CategoryOrderRequest
+    ): BaseResponse<CategoryResponse>
+
+
+    // ----------------------------------------------------
+    // [Setting]
+    // ----------------------------------------------------
 
     // [Setting] 그리드 설정 조회
     @GET("api/settings/grid")
@@ -77,9 +100,51 @@ interface AacApiService {
 
     // [Setting] 그리드 설정 수정
     @PATCH("api/settings/grid")
-    suspend fun updateGridSetting(@Body request: GridSettingRequest): GridSettingResponse
+    suspend fun updateGridSetting(
+        @Body request: GridSettingRequest
+    ): GridSettingResponse
+
+
+    // ----------------------------------------------------
+    // [AI]
+    // ----------------------------------------------------
 
     // [AI] 문장 추천
     @POST("api/ai/predictions")
-    suspend fun getAiPredictions(@Body request: AiPredictionRequest): AiPredictionResponse
+    suspend fun getAiPredictions(
+        @Body request: AiPredictionRequest
+    ): AiPredictionResponse
+
+
+    // ----------------------------------------------------
+    // [Routine - 자동 출력 문장]
+    // ----------------------------------------------------
+
+    // [Routine] 목록 조회
+    @GET("api/routines")
+    suspend fun getRoutines(): BaseResponse<RoutinesDataDto>
+
+    // [Routine] 생성
+    @POST("api/routines")
+    suspend fun createRoutine(
+        @Body request: CreateRoutineRequest
+    ): BaseResponse<RoutineDto>
+
+    // [Routine] 수정
+    @PATCH("api/routines/{id}")
+    suspend fun updateRoutine(
+        @Path("id") id: String,
+        @Body body: RoutineUpdateRequest
+    ): RoutineUpdateResponse
+
+    // [Routine] 선택 삭제
+    @HTTP(method = "DELETE", path = "api/routines", hasBody = true)
+    suspend fun deleteRoutines(
+        @Body body: DeleteRoutinesRequest
+    ): BaseResponse<DeleteRoutinesResponse>
+
+    // [Routine] 전체 삭제
+    @DELETE("api/routines/all")
+    suspend fun deleteAllRoutines(): BaseResponse<DeleteAllRoutinesResponse>
+
 }

--- a/app/src/main/java/com/example/aac/data/remote/api/AacApiService.kt
+++ b/app/src/main/java/com/example/aac/data/remote/api/AacApiService.kt
@@ -147,4 +147,25 @@ interface AacApiService {
     @DELETE("api/routines/all")
     suspend fun deleteAllRoutines(): BaseResponse<DeleteAllRoutinesResponse>
 
+    // ----------------------------------------------------
+    // [Routine Modal - 자동 출력 문장 모달]
+    // ----------------------------------------------------
+
+    // [Routine Modal] 현재 시간에 해당하는 루틴 1건 조회
+    @GET("api/routines/modal")
+    suspend fun getRoutineModal(): BaseResponse<RoutineModalResponse>
+
+    // [Routine Modal] 5분 뒤 다시 알림 (snooze)
+    @POST("api/routines/{id}/modal/snooze")
+    suspend fun snoozeRoutineModal(
+        @Path("id") id: String
+    ): BaseResponse<RoutineModalResponse>
+
+    // [Routine Modal] 오늘 끄기 (dismiss)
+    @POST("api/routines/{id}/modal/dismiss")
+    suspend fun dismissRoutineModal(
+        @Path("id") id: String
+    ): BaseResponse<RoutineModalResponse>
+
+
 }

--- a/app/src/main/java/com/example/aac/data/remote/dto/CreateRoutineRequest.kt
+++ b/app/src/main/java/com/example/aac/data/remote/dto/CreateRoutineRequest.kt
@@ -1,0 +1,23 @@
+package com.example.aac.data.remote.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class CreateRoutineRequest(
+    @SerializedName("message")
+    val message: String,
+
+    @SerializedName("scheduledTime")
+    val scheduledTime: String,   // "21:00"
+
+    @SerializedName("repeatType")
+    val repeatType: String,       // "DAILY" | "WEEKLY" | "BIWEEKLY" | "MONTHLY"
+
+    @SerializedName("daysOfWeek")
+    val daysOfWeek: List<Int> = emptyList(),
+
+    @SerializedName("daysOfMonth")
+    val daysOfMonth: List<Int> = emptyList(),
+
+    @SerializedName("isMonthEnd")
+    val isMonthEnd: Boolean = false
+)

--- a/app/src/main/java/com/example/aac/data/remote/dto/DeleteRoutinesRequest.kt
+++ b/app/src/main/java/com/example/aac/data/remote/dto/DeleteRoutinesRequest.kt
@@ -1,0 +1,8 @@
+package com.example.aac.data.remote.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class DeleteRoutinesRequest(
+    @SerializedName("ids")
+    val ids: List<String>
+)

--- a/app/src/main/java/com/example/aac/data/remote/dto/DeleteRoutinesResponse.kt
+++ b/app/src/main/java/com/example/aac/data/remote/dto/DeleteRoutinesResponse.kt
@@ -1,0 +1,15 @@
+package com.example.aac.data.remote.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class DeleteRoutinesResponse(
+    @SerializedName("deletedCount")
+    val deletedCount: Int,
+    @SerializedName("deletedIds")
+    val deletedIds: List<String>
+)
+
+data class DeleteAllRoutinesResponse(
+    @SerializedName("deletedCount")
+    val deletedCount: Int
+)

--- a/app/src/main/java/com/example/aac/data/remote/dto/RoutineDtos.kt
+++ b/app/src/main/java/com/example/aac/data/remote/dto/RoutineDtos.kt
@@ -1,0 +1,50 @@
+package com.example.aac.data.remote.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class RoutinesDataDto(
+    @SerializedName("routines")
+    val routines: List<RoutineDto>
+)
+
+data class RoutineDto(
+    @SerializedName("id")
+    val id: String,
+
+    @SerializedName("message")
+    val message: String,
+
+    @SerializedName("repeatType")
+    val repeatType: String, // "WEEKLY" 같은 값
+
+    @SerializedName("daysOfWeek")
+    val daysOfWeek: List<Int>?,
+
+    @SerializedName("daysOfMonth")
+    val daysOfMonth: List<Int>?,
+
+    @SerializedName("isMonthEnd")
+    val isMonthEnd: Boolean,
+
+    @SerializedName("scheduledTime")
+    val scheduledTime: String, // "08:30"
+
+    @SerializedName("isActive")
+    val isActive: Boolean,
+
+    @SerializedName("snoozedUntil")
+    val snoozedUntil: String?,
+
+    // ✅ 응답에 없을 수 있어서 nullable + 기본값
+    @SerializedName("startDate")
+    val startDate: String? = null,
+
+    @SerializedName("dismissedUntil")
+    val dismissedUntil: String?,
+
+    @SerializedName("createdAt")
+    val createdAt: String,
+
+    @SerializedName("updatedAt")
+    val updatedAt: String
+)

--- a/app/src/main/java/com/example/aac/data/remote/dto/RoutineModalResponse.kt
+++ b/app/src/main/java/com/example/aac/data/remote/dto/RoutineModalResponse.kt
@@ -1,0 +1,27 @@
+package com.example.aac.data.remote.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class RoutineModalResponse(
+
+    @SerializedName("routine")
+    val routine: RoutineDto?,
+
+    @SerializedName("actions")
+    val actions: RoutineModalActions?,
+
+    @SerializedName("serverTime")
+    val serverTime: String?
+)
+
+data class RoutineModalActions(
+
+    @SerializedName("snoozeMinutes")
+    val snoozeMinutes: Int?,
+
+    @SerializedName("canSnooze")
+    val canSnooze: Boolean?,
+
+    @SerializedName("canDismiss")
+    val canDismiss: Boolean?
+)

--- a/app/src/main/java/com/example/aac/data/remote/dto/RoutineUpdateRequest.kt
+++ b/app/src/main/java/com/example/aac/data/remote/dto/RoutineUpdateRequest.kt
@@ -1,0 +1,10 @@
+package com.example.aac.data.remote.dto
+
+data class RoutineUpdateRequest(
+    val message: String,
+    val scheduledTime: String,
+    val repeatType: String,
+    val daysOfWeek: List<Int>?,
+    val daysOfMonth: List<Int>?,
+    val isMonthEnd: Boolean
+)

--- a/app/src/main/java/com/example/aac/data/remote/dto/RoutineUpdateResponse.kt
+++ b/app/src/main/java/com/example/aac/data/remote/dto/RoutineUpdateResponse.kt
@@ -1,0 +1,11 @@
+package com.example.aac.data.remote.dto
+
+data class RoutineUpdateResponse(
+    val success: Boolean,
+    val data: RoutineUpdateData,
+    val message: String
+)
+
+data class RoutineUpdateData(
+    val routine: RoutineDto
+)

--- a/app/src/main/java/com/example/aac/domain/model/Routine.kt
+++ b/app/src/main/java/com/example/aac/domain/model/Routine.kt
@@ -1,0 +1,12 @@
+package com.example.aac.domain.model
+
+data class Routine(
+    val id: String,
+    val message: String,
+    val repeatType: String,
+    val daysOfWeek: List<Int>,
+    val daysOfMonth: List<Int>,
+    val isMonthEnd: Boolean,
+    val scheduledTime: String,
+    val isActive: Boolean
+)

--- a/app/src/main/java/com/example/aac/domain/repository/RoutineRepository.kt
+++ b/app/src/main/java/com/example/aac/domain/repository/RoutineRepository.kt
@@ -1,0 +1,13 @@
+package com.example.aac.domain.repository
+
+import com.example.aac.data.remote.dto.CreateRoutineRequest
+import com.example.aac.data.remote.dto.RoutineUpdateRequest
+import com.example.aac.domain.model.Routine
+
+interface RoutineRepository {
+    suspend fun getRoutines(): List<Routine>
+    suspend fun createRoutine(req: CreateRoutineRequest): Routine
+    suspend fun updateRoutine(id: String, req: RoutineUpdateRequest): Routine
+    suspend fun deleteRoutine(id: String)
+    suspend fun deleteAllRoutines()
+}

--- a/app/src/main/java/com/example/aac/domain/repository/RoutineRepositoryImpl.kt
+++ b/app/src/main/java/com/example/aac/domain/repository/RoutineRepositoryImpl.kt
@@ -1,0 +1,48 @@
+package com.example.aac.domain.repository
+
+import com.example.aac.data.mapper.toDomainRoutine
+import com.example.aac.data.remote.api.AacApiService
+import com.example.aac.data.remote.dto.CreateRoutineRequest
+import com.example.aac.data.remote.dto.RoutineUpdateRequest
+import com.example.aac.domain.model.Routine
+import com.example.aac.domain.repository.RoutineRepository
+
+class RoutineRepositoryImpl(
+    private val api: AacApiService
+) : RoutineRepository {
+
+    override suspend fun getRoutines(): List<Routine> {
+        val res = api.getRoutines()
+        if (!res.success) throw IllegalStateException(res.message)
+
+        val data = res.data ?: throw IllegalStateException("getRoutines: data is null")
+        return data.routines.map { it.toDomainRoutine() }
+    }
+
+    override suspend fun createRoutine(req: CreateRoutineRequest): Routine {
+        val res = api.createRoutine(req)
+        if (!res.success) throw IllegalStateException(res.message)
+
+        val dto = res.data ?: throw IllegalStateException("createRoutine: data is null")
+        return dto.toDomainRoutine()
+    }
+
+
+    override suspend fun updateRoutine(id: String, req: RoutineUpdateRequest): Routine {
+        val res = api.updateRoutine(id = id, body = req)
+        if (!res.success) throw IllegalStateException(res.message)
+
+        // RoutineUpdateResponse의 data가 nullable이면 여기서도 null 체크 필요
+        val routineDto = res.data.routine
+        return routineDto.toDomainRoutine()
+    }
+
+
+    override suspend fun deleteRoutine(id: String) {
+        TODO("deleteRoutine API 연결 코드 추가")
+    }
+
+    override suspend fun deleteAllRoutines() {
+        TODO("deleteAllRoutines API 연결 코드 추가")
+    }
+}

--- a/app/src/main/java/com/example/aac/ui/features/auto_sentence/AutoSentenceAddEditScreen.kt
+++ b/app/src/main/java/com/example/aac/ui/features/auto_sentence/AutoSentenceAddEditScreen.kt
@@ -91,6 +91,8 @@ fun AutoSentenceAddEditScreen(
                 onActionClick = {
                     if (isFormValid) {
                         val item = AutoSentenceItem(
+                            id = initialItem?.id ?: System.currentTimeMillis(),
+                            serverId = initialItem?.serverId ?: "",   // ADD면 아직 서버 id 없으니 빈 값
                             sentence = sentence,
                             repeatSetting = repeatSetting,
                             timeState = timeState
@@ -149,7 +151,7 @@ fun AutoSentenceAddEditScreen(
         // 여기 수정: 바깥 터치 dismiss 시에도 안전하게 닫히도록
         if (showRepeatSheet) {
             RepeatCycleBottomSheet(
-                onDismiss = { showRepeatSheet = false }, // BottomSheet 내부에서 hide 후 호출되게 바꾸는 게 핵심(RepeatCycleBottomSheet.kt에서 수정)
+                onDismiss = { showRepeatSheet = false },
                 onComplete = { newSetting ->
                     repeatSetting = newSetting
                     isRepeatSelected = true

--- a/app/src/main/java/com/example/aac/ui/features/auto_sentence/AutoSentenceItem.kt
+++ b/app/src/main/java/com/example/aac/ui/features/auto_sentence/AutoSentenceItem.kt
@@ -5,6 +5,7 @@ import com.example.aac.ui.features.auto_sentence.time.TimeState
 
 data class AutoSentenceItem(
     val id: Long = System.currentTimeMillis(),
+    val serverId: String,
     val sentence: String,
     val repeatSetting: RepeatSetting,
     val timeState: TimeState

--- a/app/src/main/java/com/example/aac/ui/features/auto_sentence/AutoSentenceRoutineViewModel.kt
+++ b/app/src/main/java/com/example/aac/ui/features/auto_sentence/AutoSentenceRoutineViewModel.kt
@@ -1,0 +1,191 @@
+package com.example.aac.ui.features.auto_sentence
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.aac.data.remote.api.RetrofitInstance
+import com.example.aac.data.remote.dto.RoutineDto
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import com.example.aac.data.remote.dto.CreateRoutineRequest
+import com.example.aac.data.remote.dto.RoutineUpdateRequest
+
+data class AutoSentenceRoutineUiState(
+    val isLoading: Boolean = false,
+    val routines: List<RoutineDto> = emptyList(),
+    val errorMessage: String? = null
+)
+
+class AutoSentenceRoutineViewModel : ViewModel() {
+
+    private val _uiState = MutableStateFlow(AutoSentenceRoutineUiState())
+    val uiState: StateFlow<AutoSentenceRoutineUiState> = _uiState
+
+    fun createRoutine(
+        request: CreateRoutineRequest,
+        onSuccess: () -> Unit
+    ) {
+        viewModelScope.launch {
+            // (선택) 로딩 표시
+            _uiState.value = _uiState.value.copy(isLoading = true, errorMessage = null)
+
+            try {
+                val res = RetrofitInstance.api.createRoutine(request)
+
+                if (res.success) {
+                    fetchRoutines()
+                    _uiState.value = _uiState.value.copy(isLoading = false)
+                    onSuccess()
+                } else {
+                    _uiState.value = _uiState.value.copy(
+                        isLoading = false,
+                        errorMessage = res.message ?: "생성 실패"
+                    )
+                }
+            } catch (e: Exception) {
+                _uiState.value = _uiState.value.copy(
+                    isLoading = false,
+                    errorMessage = "네트워크 오류"
+                )
+            }
+        }
+    }
+
+    fun fetchRoutines() {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoading = true, errorMessage = null)
+
+            try {
+                val res = RetrofitInstance.api.getRoutines()
+                if (res.success) {
+                    val list = res.data?.routines.orEmpty()
+                    _uiState.value = _uiState.value.copy(isLoading = false, routines = list)
+                    Log.d("ROUTINE", "루틴 조회 성공: ${list.size}")
+                } else {
+                    _uiState.value = _uiState.value.copy(
+                        isLoading = false,
+                        errorMessage = res.message ?: "루틴 조회 실패"
+                    )
+                }
+            } catch (e: Exception) {
+                Log.e("ROUTINE", "루틴 조회 예외", e)
+                _uiState.value = _uiState.value.copy(
+                    isLoading = false,
+                    errorMessage = "네트워크 오류"
+                )
+            }
+        }
+    }
+
+    fun updateRoutine(
+        id: String,
+        request: RoutineUpdateRequest,
+        onSuccess: () -> Unit = {}
+    ) {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoading = true, errorMessage = null)
+
+            try {
+                val res = RetrofitInstance.api.updateRoutine(id = id, body = request)
+
+                if (res.success) {
+                    val updated = res.data?.routine
+
+                    _uiState.value = _uiState.value.copy(
+                        isLoading = false,
+                        routines = if (updated != null) {
+                            _uiState.value.routines.map { if (it.id == updated.id) updated else it }
+                        } else {
+                            _uiState.value.routines
+                        }
+                    )
+
+                    onSuccess()
+                } else {
+                    _uiState.value = _uiState.value.copy(
+                        isLoading = false,
+                        errorMessage = res.message ?: "수정 실패"
+                    )
+                }
+            } catch (e: Exception) {
+                _uiState.value = _uiState.value.copy(
+                    isLoading = false,
+                    errorMessage = "네트워크 오류"
+                )
+            }
+        }
+    }
+
+    fun deleteRoutine(
+        id: String,
+        onSuccess: () -> Unit = {}
+    ) {
+        deleteRoutines(ids = listOf(id), onSuccess = onSuccess)
+    }
+
+    fun deleteRoutines(
+        ids: List<String>,
+        onSuccess: () -> Unit = {}
+    ) {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoading = true, errorMessage = null)
+
+            try {
+                val res = RetrofitInstance.api.deleteRoutines(
+                    body = com.example.aac.data.remote.dto.DeleteRoutinesRequest(ids = ids)
+                )
+
+                if (res.success) {
+                    fetchRoutines()
+                    _uiState.value = _uiState.value.copy(isLoading = false)
+                    onSuccess()
+                } else {
+                    _uiState.value = _uiState.value.copy(
+                        isLoading = false,
+                        errorMessage = res.message ?: "삭제 실패"
+                    )
+                }
+            } catch (e: Exception) {
+                Log.e("ROUTINE", "루틴 선택 삭제 예외", e)
+                _uiState.value = _uiState.value.copy(
+                    isLoading = false,
+                    errorMessage = "네트워크 오류"
+                )
+            }
+        }
+    }
+
+    fun deleteAllRoutines(
+        onSuccess: () -> Unit = {}
+    ) {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoading = true, errorMessage = null)
+
+            try {
+                val res = RetrofitInstance.api.deleteAllRoutines()
+
+                if (res.success) {
+                    fetchRoutines()
+                    onSuccess()
+                } else {
+                    _uiState.value = _uiState.value.copy(
+                        isLoading = false,
+                        errorMessage = res.message ?: "삭제 실패"
+                    )
+                }
+            } catch (e: Exception) {
+                Log.e("ROUTINE", "루틴 전체 삭제 예외", e)
+                _uiState.value = _uiState.value.copy(
+                    isLoading = false,
+                    errorMessage = "네트워크 오류"
+                )
+            }
+        }
+    }
+
+
+
+
+
+}

--- a/app/src/main/java/com/example/aac/ui/features/auto_sentence/AutoSentenceRoutineViewModel.kt
+++ b/app/src/main/java/com/example/aac/ui/features/auto_sentence/AutoSentenceRoutineViewModel.kt
@@ -4,12 +4,10 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.aac.data.remote.api.RetrofitInstance
-import com.example.aac.data.remote.dto.RoutineDto
+import com.example.aac.data.remote.dto.*
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import com.example.aac.data.remote.dto.CreateRoutineRequest
-import com.example.aac.data.remote.dto.RoutineUpdateRequest
 
 data class AutoSentenceRoutineUiState(
     val isLoading: Boolean = false,
@@ -19,35 +17,42 @@ data class AutoSentenceRoutineUiState(
 
 class AutoSentenceRoutineViewModel : ViewModel() {
 
+    // ----------------------------------------------------
+    // UI State
+    // ----------------------------------------------------
     private val _uiState = MutableStateFlow(AutoSentenceRoutineUiState())
     val uiState: StateFlow<AutoSentenceRoutineUiState> = _uiState
 
-    fun createRoutine(
-        request: CreateRoutineRequest,
-        onSuccess: () -> Unit
-    ) {
-        viewModelScope.launch {
-            // (선택) 로딩 표시
-            _uiState.value = _uiState.value.copy(isLoading = true, errorMessage = null)
+    // ----------------------------------------------------
+    // Modal State
+    // ----------------------------------------------------
+    private val _modalRoutine = MutableStateFlow<RoutineDto?>(null)
+    val modalRoutine: StateFlow<RoutineDto?> = _modalRoutine
 
+    // 현재 표시된 모달 ID (중복 방지)
+    private var currentModalId: String? = null
+
+    // ----------------------------------------------------
+    // CRUD
+    // ----------------------------------------------------
+
+    fun createRoutine(request: CreateRoutineRequest, onSuccess: () -> Unit) {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoading = true, errorMessage = null)
             try {
                 val res = RetrofitInstance.api.createRoutine(request)
-
                 if (res.success) {
                     fetchRoutines()
-                    _uiState.value = _uiState.value.copy(isLoading = false)
                     onSuccess()
                 } else {
                     _uiState.value = _uiState.value.copy(
-                        isLoading = false,
                         errorMessage = res.message ?: "생성 실패"
                     )
                 }
             } catch (e: Exception) {
-                _uiState.value = _uiState.value.copy(
-                    isLoading = false,
-                    errorMessage = "네트워크 오류"
-                )
+                _uiState.value = _uiState.value.copy(errorMessage = "네트워크 오류")
+            } finally {
+                _uiState.value = _uiState.value.copy(isLoading = false)
             }
         }
     }
@@ -55,25 +60,22 @@ class AutoSentenceRoutineViewModel : ViewModel() {
     fun fetchRoutines() {
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isLoading = true, errorMessage = null)
-
             try {
                 val res = RetrofitInstance.api.getRoutines()
                 if (res.success) {
-                    val list = res.data?.routines.orEmpty()
-                    _uiState.value = _uiState.value.copy(isLoading = false, routines = list)
-                    Log.d("ROUTINE", "루틴 조회 성공: ${list.size}")
+                    _uiState.value = _uiState.value.copy(
+                        routines = res.data?.routines.orEmpty()
+                    )
                 } else {
                     _uiState.value = _uiState.value.copy(
-                        isLoading = false,
                         errorMessage = res.message ?: "루틴 조회 실패"
                     )
                 }
             } catch (e: Exception) {
                 Log.e("ROUTINE", "루틴 조회 예외", e)
-                _uiState.value = _uiState.value.copy(
-                    isLoading = false,
-                    errorMessage = "네트워크 오류"
-                )
+                _uiState.value = _uiState.value.copy(errorMessage = "네트워크 오류")
+            } finally {
+                _uiState.value = _uiState.value.copy(isLoading = false)
             }
         }
     }
@@ -85,107 +87,131 @@ class AutoSentenceRoutineViewModel : ViewModel() {
     ) {
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isLoading = true, errorMessage = null)
-
             try {
-                val res = RetrofitInstance.api.updateRoutine(id = id, body = request)
-
+                val res = RetrofitInstance.api.updateRoutine(id, request)
                 if (res.success) {
                     val updated = res.data?.routine
-
                     _uiState.value = _uiState.value.copy(
-                        isLoading = false,
-                        routines = if (updated != null) {
-                            _uiState.value.routines.map { if (it.id == updated.id) updated else it }
-                        } else {
-                            _uiState.value.routines
+                        routines = _uiState.value.routines.map {
+                            if (it.id == updated?.id) updated else it
                         }
                     )
-
                     onSuccess()
                 } else {
                     _uiState.value = _uiState.value.copy(
-                        isLoading = false,
                         errorMessage = res.message ?: "수정 실패"
                     )
                 }
             } catch (e: Exception) {
-                _uiState.value = _uiState.value.copy(
-                    isLoading = false,
-                    errorMessage = "네트워크 오류"
-                )
+                _uiState.value = _uiState.value.copy(errorMessage = "네트워크 오류")
+            } finally {
+                _uiState.value = _uiState.value.copy(isLoading = false)
             }
         }
     }
 
-    fun deleteRoutine(
-        id: String,
-        onSuccess: () -> Unit = {}
-    ) {
-        deleteRoutines(ids = listOf(id), onSuccess = onSuccess)
+    fun deleteRoutine(id: String, onSuccess: () -> Unit = {}) {
+        deleteRoutines(listOf(id), onSuccess)
     }
 
-    fun deleteRoutines(
-        ids: List<String>,
-        onSuccess: () -> Unit = {}
-    ) {
+    fun deleteRoutines(ids: List<String>, onSuccess: () -> Unit = {}) {
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isLoading = true, errorMessage = null)
-
             try {
-                val res = RetrofitInstance.api.deleteRoutines(
-                    body = com.example.aac.data.remote.dto.DeleteRoutinesRequest(ids = ids)
-                )
-
+                val res = RetrofitInstance.api.deleteRoutines(DeleteRoutinesRequest(ids))
                 if (res.success) {
                     fetchRoutines()
-                    _uiState.value = _uiState.value.copy(isLoading = false)
                     onSuccess()
                 } else {
                     _uiState.value = _uiState.value.copy(
-                        isLoading = false,
                         errorMessage = res.message ?: "삭제 실패"
                     )
                 }
             } catch (e: Exception) {
-                Log.e("ROUTINE", "루틴 선택 삭제 예외", e)
-                _uiState.value = _uiState.value.copy(
-                    isLoading = false,
-                    errorMessage = "네트워크 오류"
-                )
+                Log.e("ROUTINE", "삭제 예외", e)
+                _uiState.value = _uiState.value.copy(errorMessage = "네트워크 오류")
+            } finally {
+                _uiState.value = _uiState.value.copy(isLoading = false)
             }
         }
     }
 
-    fun deleteAllRoutines(
-        onSuccess: () -> Unit = {}
-    ) {
+    fun deleteAllRoutines(onSuccess: () -> Unit = {}) {
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isLoading = true, errorMessage = null)
-
             try {
                 val res = RetrofitInstance.api.deleteAllRoutines()
-
                 if (res.success) {
                     fetchRoutines()
                     onSuccess()
                 } else {
                     _uiState.value = _uiState.value.copy(
-                        isLoading = false,
                         errorMessage = res.message ?: "삭제 실패"
                     )
                 }
             } catch (e: Exception) {
-                Log.e("ROUTINE", "루틴 전체 삭제 예외", e)
-                _uiState.value = _uiState.value.copy(
-                    isLoading = false,
-                    errorMessage = "네트워크 오류"
-                )
+                Log.e("ROUTINE", "전체 삭제 예외", e)
+                _uiState.value = _uiState.value.copy(errorMessage = "네트워크 오류")
+            } finally {
+                _uiState.value = _uiState.value.copy(isLoading = false)
             }
         }
     }
 
+    // ----------------------------------------------------
+    // Modal (Polling 기반)
+    // ----------------------------------------------------
 
+    fun checkRoutineModal() {
+        viewModelScope.launch {
+            try {
+                val res = RetrofitInstance.api.getRoutineModal()
+                if (res.success) {
+                    val routine = res.data?.routine
+                    Log.d("MODAL", "서버 응답 id = ${routine?.id}")
 
+                    // 같은 루틴은 다시 표시하지 않음
+                    if (routine != null && routine.id != currentModalId) {
+                        currentModalId = routine.id
+                        _modalRoutine.value = routine
+                    }
+                }
+            } catch (e: Exception) {
+                Log.e("MODAL", "checkRoutineModal 실패", e)
+            }
+        }
+    }
 
+    fun snoozeRoutine(id: String) {
+        clearModal() // UI 즉시 닫기
+        viewModelScope.launch {
+            try {
+                val res = RetrofitInstance.api.snoozeRoutineModal(id)
+                if (!res.success) {
+                    Log.e("MODAL", "snooze 실패 응답")
+                }
+            } catch (e: Exception) {
+                Log.e("MODAL", "snooze 네트워크 실패", e)
+            }
+        }
+    }
 
+    fun dismissRoutine(id: String) {
+        clearModal() // UI 즉시 닫기
+        viewModelScope.launch {
+            try {
+                val res = RetrofitInstance.api.dismissRoutineModal(id)
+                if (!res.success) {
+                    Log.e("MODAL", "dismiss 실패 응답")
+                }
+            } catch (e: Exception) {
+                Log.e("MODAL", "dismiss 네트워크 실패", e)
+            }
+        }
+    }
+
+    fun clearModal() {
+        _modalRoutine.value = null
+        currentModalId = null
+    }
 }

--- a/app/src/main/java/com/example/aac/ui/features/auto_sentence/components/RoutineModal.kt
+++ b/app/src/main/java/com/example/aac/ui/features/auto_sentence/components/RoutineModal.kt
@@ -1,0 +1,214 @@
+package com.example.aac.ui.features.auto_sentence.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.aac.R
+import com.example.aac.data.remote.dto.RoutineDto
+
+@Composable
+fun RoutineModal(
+    routine: RoutineDto,
+    onSnoozeClick: () -> Unit,
+    onDismissClick: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0xC7191919)),
+        contentAlignment = Alignment.Center
+    ) {
+        Box(
+            modifier = Modifier
+                .width(530.dp)
+                .height(457.dp)
+                .background(
+                    color = Color(0xFFF3F4F7),
+                    shape = RoundedCornerShape(32.dp)
+                )
+                .padding(horizontal = 51.dp, vertical = 40.dp)
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+
+                // 🔵 벨 아이콘 원
+                Box(
+                    modifier = Modifier
+                        .size(88.dp)
+                        .background(Color(0xFF99C1FF), CircleShape),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_bell),
+                        contentDescription = null,
+                        tint = Color.White,
+                        modifier = Modifier.size(70.dp)
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(40.dp))
+
+                Text(
+                    text = routine.message,
+                    fontSize = 32.sp,
+                    fontWeight = FontWeight.Medium,
+                    color = Color(0xFF2C2C2C),
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                Text(
+                    text = formatToKoreanAmPm(routine.scheduledTime),
+                    fontSize = 20.sp,
+                    fontWeight = FontWeight.Medium,
+                    color = Color(0xFF2C2C2C),
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                Spacer(modifier = Modifier.height(40.dp))
+
+                // 🔵 재생 버튼
+                Box(
+                    modifier = Modifier
+                        .width(428.dp)
+                        .height(60.dp)
+                        .background(Color(0xFF0088FF), RoundedCornerShape(8.dp))
+                        .border(1.dp, Color(0xFFD9D9D9), RoundedCornerShape(8.dp)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Center
+                    ) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_sound),
+                            contentDescription = null,
+                            tint = Color.White,
+                            modifier = Modifier.size(22.dp)
+                        )
+
+                        Spacer(modifier = Modifier.width(8.dp))
+
+                        Text(
+                            text = "재생",
+                            fontSize = 20.sp,
+                            fontWeight = FontWeight.Medium,
+                            color = Color.White
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(15.dp))
+
+                // 🔘 하단 두 버튼
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(15.dp)
+                ) {
+
+                    // 5분 뒤 다시 알림
+                    Box(
+                        modifier = Modifier
+                            .width(206.5.dp)
+                            .height(60.dp)
+                            .background(Color(0xFFE2E5EA), RoundedCornerShape(8.dp))
+                            .border(1.dp, Color(0xFFD9D9D9), RoundedCornerShape(8.dp))
+                            .clickable { onSnoozeClick() },
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = "5분 뒤 다시 알림",
+                            fontSize = 20.sp,
+                            fontWeight = FontWeight.Medium,
+                            color = Color.Black
+                        )
+                    }
+
+                    // 끄기
+                    Box(
+                        modifier = Modifier
+                            .width(206.5.dp)
+                            .height(60.dp)
+                            .background(Color(0xFFE2E5EA), RoundedCornerShape(8.dp))
+                            .border(1.dp, Color(0xFFD9D9D9), RoundedCornerShape(8.dp))
+                            .clickable { onDismissClick() },
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = "끄기",
+                            fontSize = 20.sp,
+                            fontWeight = FontWeight.Medium,
+                            color = Color(0xFFB80000)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun formatToKoreanAmPm(time: String): String {
+    return try {
+        val parts = time.split(":")
+        val hour = parts[0].toInt()
+        val minute = parts[1]
+
+        val amPm = if (hour < 12) "오전" else "오후"
+
+        val displayHour = when {
+            hour == 0 -> 12
+            hour > 12 -> hour - 12
+            else -> hour
+        }
+
+        "$amPm $displayHour:$minute"
+    } catch (e: Exception) {
+        time
+    }
+}
+
+@Preview(
+    showBackground = true,
+    widthDp = 1280,
+    heightDp = 800
+)
+@Composable
+fun RoutineModalPreview() {
+    RoutineModal(
+        routine = RoutineDto(
+            id = "1",
+            message = "물을 끓여와주세요.",
+            repeatType = "WEEKLY",
+            daysOfWeek = listOf(2, 4, 6),
+            daysOfMonth = listOf(),
+            isMonthEnd = false,
+            scheduledTime = "08:30",
+            isActive = true,
+            snoozedUntil = null,
+            dismissedUntil = null,
+            createdAt = "",
+            updatedAt = ""
+        ),
+        onSnoozeClick = {},
+        onDismissClick = {}
+    )
+}
+

--- a/app/src/main/res/drawable/ic_bell.xml
+++ b/app/src/main/res/drawable/ic_bell.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="70dp"
+    android:height="70dp"
+    android:viewportWidth="70"
+    android:viewportHeight="70">
+  <path
+      android:pathData="M35,12.143C26.177,12.143 20.294,18.445 20.294,26.848V35.777C20.294,39.453 18.529,43.13 16.177,45.756L15,47.857H55L53.824,45.756C51.471,43.13 49.706,39.453 49.706,35.777V26.848C49.706,18.445 43.824,12.143 35,12.143Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="5"
+      android:fillColor="#ffffff"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M41.429,51.071C41.429,52.492 40.752,53.854 39.547,54.859C38.341,55.864 36.706,56.428 35.001,56.428C33.296,56.428 31.661,55.864 30.455,54.859C29.25,53.854 28.572,52.492 28.572,51.071L35.001,51.071H41.429Z"
+      android:fillColor="#ffffff"/>
+</vector>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ uiUnit = "1.10.1"
 foundation = "1.10.1"
 ui = "1.10.1"
 runtimeVersion = "1.10.2"
+foundationVersion = "1.10.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -43,6 +44,7 @@ androidx-compose-ui-unit = { group = "androidx.compose.ui", name = "ui-unit", ve
 androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "foundation" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui", version.ref = "ui" }
 androidx-runtime = { group = "androidx.compose.runtime", name = "runtime", version.ref = "runtimeVersion" }
+androidx-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "foundationVersion" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
# [AutoSentence] 전역 Routine Modal Polling 적용 및 상태 관리 리팩토링

## 📌 변경 목적

- 자동 출력 문장(Routine) 모달을 앱 전역에서 표시할 수 있도록 구조 개선
- `AppNavGraph` 레벨에서 1분 polling 적용
- Modal 상태를 ViewModel 기반으로 관리하도록 리팩토링
- Snooze / Dismiss 시 UI 즉시 반영되도록 개선
- Polling 중복 노출 방지 로직 추가

---

## 🔥 주요 변경 사항

### 1️⃣ AppNavGraph 전역 polling 적용

```kotlin
LaunchedEffect(Unit) {
    while (true) {
        routineVm.checkRoutineModal()
        delay(60_000)
    }
}

-앱 실행 중 1분마다 /api/routines/modal 호출
-서버가 routine 반환 시 전역 모달 표시
-polling 구조 특성상 최대 1분 오차 발생 가능

---
## 머지 시 주의 사항

-Modal polling은 AppNavGraph 단일 위치에서만 관리
→ 다른 화면에서 중복 polling 로직 추가 금지

-Modal 표시/제거는 ViewModel 상태 기반으로만 제어
→ UI에서 직접 상태 제어하지 않도록 유지

-향후 FCM 등 push 기반 구조로 전환 시 polling 제거 가능